### PR TITLE
Enriquecer el modelo Resources [ISSUE#50]

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -26,7 +26,7 @@ class ResourceController extends Controller
 
     /**
      * @OA\Get(
-     *  path="/api/resources/lists",
+     *  path="/api/resources",
      *  summary="Get all resources",
      *  description="return a list of all resources",
      *  @OA\Response(

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -34,6 +34,9 @@ class StoreResourceRequest extends FormRequest
             'description' => ['required', 'string', 'min:10', 'max:1000'],
             'title' => ['required', 'string', 'min:5', 'max:255'],
             'url' => ['required', 'url'],
+            'category' => ['required', 'string', 'in:Node,React,Angular,Javascript,Java,Fullstack PHP,Data Science, BBDD'],
+            'theme' => ['required', 'string', 'in:All,Components,UseState & UseEffect,Eventos,Renderizado condicional,Listas,Estilos,Debugging,React Router'],
+            'type' =>['required', 'string', 'in:Video,Cursos,Blog']
         ];
        
     }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -29,6 +29,10 @@ class Resource extends Model
         'description',
         'title',
         'url',
+        'category',
+        'theme',
+        'type',
+        'votes'
     ];
 
     public function role()

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -19,8 +19,8 @@ use Illuminate\Database\Eloquent\Model;
      *      @OA\Property(property="url", type="string", nullable=true, example="https://www.hola.com", format="url"),
      *      @OA\Property(property="category", type="string", enum={"Node","React","Angular","Javascript","Java","Fullstack PHP", "Data Science","BBDD"}, example="Node"),
      *      @OA\Property(property="theme", type="string", enum={"All","Components","UseState & UseEffect","Eventos","Renderizado condicional","Listas", "Estilos","Debugging", "React Router"}, example="All"),
-     *      @OA\Property(property="type", type="string", enum={"Video","Cursos,"Blog"}, example="Video"),
-     *      @OA\Property(property="votes" type="integer", example = 1)
+     *      @OA\Property(property="type", type="string", enum={"Video","Cursos","Blog"}, example="Video"),
+     *      @OA\Property(property="votes", type="integer", example = 1)
      * )
      */
 class Resource extends Model

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -16,7 +16,11 @@ use Illuminate\Database\Eloquent\Model;
      *      @OA\Property(property="github_id", type="integer", example=12345),
      *      @OA\Property(property="description", type="string", nullable=true, example="Lorem Ipsum ..."),
      *      @OA\Property(property="title", type="string", nullable=true, example="Lorem Ipsum ..."),
-     *      @OA\Property(property="url", type="string", nullable=true, example="https://www.hola.com", format="url")
+     *      @OA\Property(property="url", type="string", nullable=true, example="https://www.hola.com", format="url"),
+     *      @OA\Property(property="category", type="string", enum={"Node","React","Angular","Javascript","Java","Fullstack PHP", "Data Science","BBDD"}, example="Node"),
+     *      @OA\Property(property="theme", type="string", enum={"All","Components","UseState & UseEffect","Eventos","Renderizado condicional","Listas", "Estilos","Debugging", "React Router"}, example="All"),
+     *      @OA\Property(property="type", type="string", enum={"Video","Cursos,"Blog"}, example="Video"),
+     *      @OA\Property(property="votes" type="integer", example = 1)
      * )
      */
 class Resource extends Model

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -27,7 +27,11 @@ class ResourceFactory extends Factory
             'github_id' => $role->github_id,
             'title' => $this->faker->sentence(4),
             'description' => $this->faker->sentence(6),
-            'url' => $this->faker->url()
+            'url' => $this->faker->url(),
+            'category' => $this->faker->randomElement(['Node', 'React', 'Angular', 'Javascript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']),
+            'theme' => $this->faker->randomElement(['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']),
+            'type' => $this->faker->randomElement(['Video', 'Cursos', 'Blog']),
+            'votes' => $this->faker->random_int(0,50)
         ];
     }
 }

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -31,7 +31,7 @@ class ResourceFactory extends Factory
             'category' => $this->faker->randomElement(['Node', 'React', 'Angular', 'Javascript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']),
             'theme' => $this->faker->randomElement(['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']),
             'type' => $this->faker->randomElement(['Video', 'Cursos', 'Blog']),
-            'votes' => $this->faker->random_int(0,50)
+            'votes' => $this->faker->numberBetween(0,50)
         ];
     }
 }

--- a/database/migrations/2025_02_12_120510_create_resources_table.php
+++ b/database/migrations/2025_02_12_120510_create_resources_table.php
@@ -27,7 +27,7 @@ return new class extends Migration
             $table->enum('category', ['Node', 'React', 'Angular', 'Javascript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']);
             $table->enum('theme', ['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']);
             $table->enum('type', ['Video', 'Cursos', 'Blog']);
-            $table->int('votes');
+            $table->integer('votes');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_02_12_120510_create_resources_table.php
+++ b/database/migrations/2025_02_12_120510_create_resources_table.php
@@ -24,6 +24,10 @@ return new class extends Migration
             $table->string('title');
             $table->string('description');
             $table->string('url');
+            $table->enum('category', ['Node', 'React', 'Angular', 'Javascript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']);
+            $table->enum('theme', ['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']);
+            $table->enum('type', ['Video', 'Cursos', 'Blog']);
+            $table->int('votes');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_02_12_120510_create_resources_table.php
+++ b/database/migrations/2025_02_12_120510_create_resources_table.php
@@ -27,7 +27,7 @@ return new class extends Migration
             $table->enum('category', ['Node', 'React', 'Angular', 'Javascript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']);
             $table->enum('theme', ['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']);
             $table->enum('type', ['Video', 'Cursos', 'Blog']);
-            $table->integer('votes');
+            $table->integer('votes')->default(0);
             $table->timestamps();
         });
     }

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -6,11 +6,11 @@
         "version": "1.0.0.0"
     },
     "paths": {
-        "/api/resources/lists": {
+        "/api/resources": {
             "get": {
                 "summary": "Get all resources",
                 "description": "return a list of all resources",
-                "operationId": "9e5d89c5eb6c40040231787df8926fda",
+                "operationId": "ee96de2f37d473ea4740b7700ddd1daf",
                 "responses": {
                     "200": {
                         "description": "Resource list",


### PR DESCRIPTION
El modelo y migracion de Resources ya esta enriquecido con los campos de categoría, tema, tipo y votos.

El endpoint de GET /api/resources esta documentado, y se ha modificado el modelo para que aparezcan ahora correctamente los datos en swagger.

La factory esta modificada para que cree ahora también los campos nuevos y les de un valor dentro de los seleccionados, ademas los votos se generan aleatoriamente entre 0 y 50 para que frontend pueda testear el orden por votos.

Quedo pendiente de revisión.

