### PR TITLE
add role_creation endpoint to swagger

### DIFF
--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -137,6 +137,9 @@
         },
         "/api/resources": {
             "get": {
+                "tags": [
+                    "Resources"
+                ],
                 "summary": "Get all resources",
                 "description": "return a list of all resources",
                 "operationId": "ee96de2f37d473ea4740b7700ddd1daf",
@@ -162,11 +165,90 @@
                 }
             }
         },
+        "/api/roles": {
+            "post": {
+                "tags": [
+                    "Roles"
+                ],
+                "summary": "Create a new role",
+                "description": "Allows an authorized user to create a new role for a specific GitHub ID.",
+                "operationId": "4131bb39b430bdf2d95b73111d2e126a",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "github_id",
+                                    "role",
+                                    "authorized_github_id"
+                                ],
+                                "properties": {
+                                    "github_id": {
+                                        "description": "GitHub ID of the user to assign the role",
+                                        "type": "integer",
+                                        "example": 12345
+                                    },
+                                    "role": {
+                                        "description": "Role to be assigned",
+                                        "type": "string",
+                                        "example": "mentor"
+                                    },
+                                    "authorized_github_id": {
+                                        "description": "GitHub ID of the user making the request (must have permissions)",
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Role created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Rol creado con éxito."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Unauthorized: Cannot create a role equal or higher than your own",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "No puedes crear un rol igual o superior al tuyo."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/login": {
             "post": {
+                "tags": [
+                    "Roles"
+                ],
                 "summary": "Retrieve a role by GitHub ID",
                 "description": "Fetches a role using the provided GitHub ID. If the role does not exist, it returns an error.",
-                "operationId": "902de143a0c91c68a1742a2a0907a700",
+                "operationId": "b381f169e17b927e71d392ff0f3d4ce5",
                 "parameters": [
                     {
                         "name": "github_id",


### PR DESCRIPTION
Faltó generar de nuevo la documentación en swagger. Ahora también está más ordenado al poner los tags correctos para resources y roles.