### PR TITLE
Feature/resource theme replaced by tags

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -33,7 +33,7 @@ class ResourceController extends Controller
      *             @OA\Property(property="description", type="string", minLength=10, maxLength=1000, example="A collection of best practices for Laravel development", description="Description of the resource (10-1000 characters)"),
      *             @OA\Property(property="url", type="string", format="url", example="https://laravelbestpractices.com", description="URL of the resource"),
      *             @OA\Property(property="category", type="string", enum={"Node","React","Angular","JavaScript","Java","Fullstack PHP","Data Science","BBDD"}, example="React", description="Category of the resource"),
-     *             @OA\Property(property="tags", type="array", @OA\Items(type="string", example="oop"), description=""Array of tags validated against available options (nullable)"),
+     *             @OA\Property(property="tags", type="array", @OA\Items(type="string", example="oop"), description="Array of tags validated against available options (nullable)"),
      *             @OA\Property(property="type", type="string", enum={"Video","Cursos","Blog"}, example="Video", description="Type of the resource")
      *         )
      *     ),

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -27,13 +27,13 @@ class ResourceController extends Controller
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             required={"github_id", "title", "description", "url", "category", "theme", "type"},
+     *             required={"github_id", "title", "description", "url", "category", "type"},
      *             @OA\Property(property="github_id", type="integer", example=6729608, description="GitHub ID of an existing user role creating the resource"),
      *             @OA\Property(property="title", type="string", minLength=5, maxLength=255, example="Laravel Best Practices", description="Title of the resource"),
      *             @OA\Property(property="description", type="string", minLength=10, maxLength=1000, example="A collection of best practices for Laravel development", description="Description of the resource (10-1000 characters)"),
      *             @OA\Property(property="url", type="string", format="url", example="https://laravelbestpractices.com", description="URL of the resource"),
      *             @OA\Property(property="category", type="string", enum={"Node","React","Angular","JavaScript","Java","Fullstack PHP","Data Science","BBDD"}, example="React", description="Category of the resource"),
-     *             @OA\Property(property="theme", type="string", enum={"All","Components","UseState & UseEffect","Eventos","Renderizado condicional","Listas","Estilos","Debugging","React Router"}, example="Components", description="Theme of the resource"),
+     *             @OA\Property(property="tags", type="array", @OA\Items(type="string", example="oop"), description=""Array of tags validated against available options (nullable)"),
      *             @OA\Property(property="type", type="string", enum={"Video","Cursos","Blog"}, example="Video", description="Type of the resource")
      *         )
      *     ),
@@ -53,7 +53,7 @@ class ResourceController extends Controller
      *                 "description": {"The description field is required.", "Description must be at least 10 characters.", "Description must not exceed 1000 characters."},
      *                 "url": {"The url field is required.", "The url format is invalid."},
      *                 "category": {"The category field is required.", "The selected category is invalid."},
-     *                 "theme": {"The theme field is required.", "The selected theme is invalid."},
+     *                 "tags": {"The tags field must be an array of strings.", "The selected tags are invalid."},
      *                 "type": {"The type field is required.", "The selected type is invalid."}
      *             })
      *         )

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -12,7 +12,7 @@ class TagController extends Controller
 {
     /**
      * @OA\Get(
-     *     path="/tags",
+     *     path="/api/tags",
      *     summary="Get all tags",
      *     tags={"Tags"},
      *     description="Tags used in resources",
@@ -35,18 +35,14 @@ class TagController extends Controller
 
     /**
      * @OA\Get(
-     *     path="/tags/frequency",
+     *     path="/api/tags/frequency",
      *     summary="Get tag frequencies",
      *     tags={"Tags"},
      *     description="Frequencies of tags used in resources",
      *     @OA\Response(
      *         response=200,
      *         description="An object with tag names as keys and frequencies as values",
-     *         @OA\JsonContent(
-     *             type="object",
-     *             additionalProperties=@OA\Schema(type="integer"),
-     *             example={"mongodb": 3, "rest": 5, "oop": 2}
-     *         )
+     *         @OA\JsonContent(type="object")
      *     )
      * )
     */

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -6,29 +6,60 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Tag;
-
-/**
- * @OA\Get(
- *     path="/tags",
- *     summary="Get all tags",
- *     tags={"Tags"},
- *     description="Tags used in resources",
- *     @OA\Response(
- *         response=200,
- *         description="A list of tags",
- *         @OA\JsonContent(
- *             type="array",
- *             @OA\Items(ref="#/components/schemas/Tag")
- *         )
- *     )
- * )
-*/
+use App\Models\Resource;
 
 class TagController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/tags",
+     *     summary="Get all tags",
+     *     tags={"Tags"},
+     *     description="Tags used in resources",
+     *     @OA\Response(
+     *         response=200,
+     *         description="A list of tags",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(ref="#/components/schemas/Tag")
+     *         )
+     *     )
+     * )
+    */
+
     public function index()
     {
         $tags = Tag::all();
         return response()->json($tags, 200);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/tags/frequency",
+     *     summary="Get tag frequencies",
+     *     tags={"Tags"},
+     *     description="Frequencies of tags used in resources",
+     *     @OA\Response(
+     *         response=200,
+     *         description="An object with tag names as keys and frequencies as values",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             additionalProperties=@OA\Schema(type="integer"),
+     *             example={"mongodb": 3, "rest": 5, "oop": 2}
+     *         )
+     *     )
+     * )
+    */
+
+    public function getTagsFrequency()
+    {
+        $frequencies = Resource::all()
+            ->pluck('tags')
+            ->filter()
+            ->flatten()
+            ->countBy()
+            ->all();
+
+        return response()->json($frequencies, 200);
     }
 }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare (strict_types= 1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Tag;
+
+/**
+ * @OA\Get(
+ *     path="/tags",
+ *     summary="Get all tags",
+ *     tags={"Tags"},
+ *     description="Tags used in resources",
+ *     @OA\Response(
+ *         response=200,
+ *         description="A list of tags",
+ *         @OA\JsonContent(
+ *             type="array",
+ *             @OA\Items(ref="#/components/schemas/Tag")
+ *         )
+ *     )
+ * )
+*/
+
+class TagController extends Controller
+{
+    public function index()
+    {
+        $tags = Tag::all();
+        return response()->json($tags, 200);
+    }
+}

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -4,8 +4,10 @@ declare (strict_types= 1);
 
 namespace App\Http\Requests;
 
-use App\Rules\RoleAnonymousRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Rules\GithubIdRule;
+use App\Rules\RoleStudentRule;
 
 class StoreResourceRequest extends FormRequest
 {
@@ -24,18 +26,32 @@ class StoreResourceRequest extends FormRequest
      */
     public function rules(): array
     {
+        // Static validation (temporary until tags table exists)
+        // Once model Tag is done, eliminate variable below and also line 52. Uncomment 53
+        $validTags = [
+            'Components', 
+            'UseState & UseEffect', 
+            'Eventos',
+            'Renderizado condicional', 
+            'Listas', 
+            'Estilos', 
+            'Debugging', 
+            'React Router'
+        ];
+
         return [
             'github_id' => [
-                'required',
-                'exists:roles,github_id'
+                new GithubIdRule(),
+                new RoleStudentRule(), // Comment if you don't want to restrict to students only
             ],
             'description' => ['required', 'string', 'min:10', 'max:1000'],
             'title' => ['required', 'string', 'min:5', 'max:255'],
             'url' => ['required', 'url'],
             'category' => ['required', 'string', 'in:Node,React,Angular,JavaScript,Java,Fullstack PHP,Data Science,BBDD'],
-            'theme' => ['required', 'string', 'in:All,Components,UseState & UseEffect,Eventos,Renderizado condicional,Listas,Estilos,Debugging,React Router'],
+            'tags' => ['nullable', 'array'],
+            'tags.*' => ['string', Rule::in($validTags)],
+            // 'tags.*' => ['string', Rule::exists('tags', 'name')],
             'type' =>['required', 'string', 'in:Video,Cursos,Blog']
         ];
-       
     }  
 }

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -26,19 +26,6 @@ class StoreResourceRequest extends FormRequest
      */
     public function rules(): array
     {
-        // Static validation (temporary until tags table exists)
-        // Once model Tag is done, eliminate variable below and also line 52. Uncomment 53
-        $validTags = [
-            'Components', 
-            'UseState & UseEffect', 
-            'Eventos',
-            'Renderizado condicional', 
-            'Listas', 
-            'Estilos', 
-            'Debugging', 
-            'React Router'
-        ];
-
         return [
             'github_id' => [
                 new GithubIdRule(),
@@ -49,8 +36,7 @@ class StoreResourceRequest extends FormRequest
             'url' => ['required', 'url'],
             'category' => ['required', 'string', 'in:Node,React,Angular,JavaScript,Java,Fullstack PHP,Data Science,BBDD'],
             'tags' => ['nullable', 'array'],
-            'tags.*' => ['string', Rule::in($validTags)],
-            // 'tags.*' => ['string', Rule::exists('tags', 'name')],
+            'tags.*' => ['string', Rule::exists('tags', 'name')],
             'type' =>['required', 'string', 'in:Video,Cursos,Blog']
         ];
     }  

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -14,11 +14,11 @@ use Illuminate\Database\Eloquent\Model;
      *      title="Resource",
      *      @OA\Property(property="id", type="integer", example=1),
      *      @OA\Property(property="github_id", type="integer", example=12345),
-     *      @OA\Property(property="description", type="string", nullable=true, example="Lorem Ipsum ..."),
      *      @OA\Property(property="title", type="string", nullable=true, example="Lorem Ipsum ..."),
+     *      @OA\Property(property="description", type="string", nullable=true, example="Lorem Ipsum ..."),
      *      @OA\Property(property="url", type="string", nullable=true, example="https://www.hola.com", format="url"),
      *      @OA\Property(property="category", type="string", enum={"Node","React","Angular","JavaScript","Java","Fullstack PHP", "Data Science","BBDD"}, example="Node"),
-     *      @OA\Property(property="theme", type="string", enum={"All","Components","UseState & UseEffect","Eventos","Renderizado condicional","Listas", "Estilos","Debugging", "React Router"}, example="All"),
+     *      @OA\Property(property="tags", type="array", @OA\items(type="string"), example={"Components","UseState & UseEffect","Eventos" ,"Renderizado condicional","Listas","Estilos","Debugging","React Router"}), description="Array of tags",
      *      @OA\Property(property="type", type="string", enum={"Video","Cursos","Blog"}, example="Video"),
      *      @OA\Property(property="bookmark_count", type="integer", example = 1),
      *      @OA\Property(property="like_count", type="integer", example = 1),
@@ -33,14 +33,18 @@ class Resource extends Model
 
     protected $fillable = [
         'github_id',
-        'description',
         'title',
+        'description',
         'url',
         'category',
-        'theme',
+        'tags',
         'type',
         'bookmark_count',
         'like_count'
+    ];
+
+    protected $casts = [
+        'tags' => 'array'
     ];
 
     public function role()

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Model;
      *      @OA\Property(property="description", type="string", nullable=true, example="Lorem Ipsum ..."),
      *      @OA\Property(property="url", type="string", nullable=true, example="https://www.hola.com", format="url"),
      *      @OA\Property(property="category", type="string", enum={"Node","React","Angular","JavaScript","Java","Fullstack PHP", "Data Science","BBDD"}, example="Node"),
-     *      @OA\Property(property="tags", type="array", @OA\items(type="string"), example={"Components","UseState & UseEffect","Eventos" ,"Renderizado condicional","Listas","Estilos","Debugging","React Router"}), description="Array of tags",
+     *      @OA\Property(property="tags", type="array", @OA\items(type="string"), example={"kubernetes", "sql", "azure"}, description="Array of tags"),
      *      @OA\Property(property="type", type="string", enum={"Video","Cursos","Blog"}, example="Video"),
      *      @OA\Property(property="bookmark_count", type="integer", example = 1),
      *      @OA\Property(property="like_count", type="integer", example = 1),

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,31 @@
+<?php
+declare (strict_types= 1);
+
+namespace App\Models;
+
+//use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @OA\Schema(
+ *   schema="Tag",
+ *   type="object",
+ *   title="Tag",
+ *   description="Tags used in resources",
+ *   @OA\Property(property="id", type="integer", example=1),
+ *   @OA\Property(property="name", type="string", example="debugging"),
+ *   @OA\Property(property="created_at", type="string", format="date-time", example="2025-03-17T19:23:41.000000Z"),
+ *   @OA\Property(property="updated_at", type="string", format="date-time", example="2025-03-17T19:23:41.000000Z")
+ * )
+ */
+
+class Tag extends Model
+{
+    //use HasFactory;
+    protected $table = 'tags';
+    protected $fillable = ['name'];
+
+    protected $casts = [
+        'name' => 'string',
+    ];
+}

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -24,20 +24,6 @@ class ResourceFactory extends Factory
         ->inRandomOrder()
         ->first();
 
-        /* Eliminate lines 26 to 36 when model Tag is done
-        $validTags = [
-            'Components', 
-            'UseState & UseEffect', 
-            'Eventos',
-            'Renderizado condicional', 
-            'Listas', 
-            'Estilos', 
-            'Debugging', 
-            'React Router'
-        ];
-        */
-
-        // Uncomment line below when model Tag is done
         $validTags = Tag::all()->pluck('name')->toArray();
 
         return [

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -23,13 +23,28 @@ class ResourceFactory extends Factory
         ->inRandomOrder()
         ->first();
 
+        // Eliminate lines 26 to 36 when model Tag is done
+        $validTags = [
+            'Components', 
+            'UseState & UseEffect', 
+            'Eventos',
+            'Renderizado condicional', 
+            'Listas', 
+            'Estilos', 
+            'Debugging', 
+            'React Router'
+        ];
+
+        // Uncomment line below when model Tag is done
+        // $validTags = Tag::all()->pluck('name')->toArray();
+
         return [
             'github_id' => $role->github_id,
             'title' => $this->faker->sentence(4),
             'description' => $this->faker->sentence(6),
             'url' => $this->faker->url(),
             'category' => $this->faker->randomElement(['Node', 'React', 'Angular', 'JavaScript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']),
-            'theme' => $this->faker->randomElement(['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']),
+            'tags' => $this->faker->randomElements($validTags, $this->faker->numberBetween(1, 5)),
             'type' => $this->faker->randomElement(['Video', 'Cursos', 'Blog']),
         ];
     }

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -5,6 +5,7 @@ declare (strict_types= 1);
 namespace Database\Factories;
 
 use App\Models\Role;
+use App\Models\Tag;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -23,7 +24,7 @@ class ResourceFactory extends Factory
         ->inRandomOrder()
         ->first();
 
-        // Eliminate lines 26 to 36 when model Tag is done
+        /* Eliminate lines 26 to 36 when model Tag is done
         $validTags = [
             'Components', 
             'UseState & UseEffect', 
@@ -34,9 +35,10 @@ class ResourceFactory extends Factory
             'Debugging', 
             'React Router'
         ];
+        */
 
         // Uncomment line below when model Tag is done
-        // $validTags = Tag::all()->pluck('name')->toArray();
+        $validTags = Tag::all()->pluck('name')->toArray();
 
         return [
             'github_id' => $role->github_id,

--- a/database/migrations/2025_02_12_120500_create_tags_table.php
+++ b/database/migrations/2025_02_12_120500_create_tags_table.php
@@ -1,0 +1,29 @@
+<?php
+declare (strict_types= 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2025_02_12_120510_create_resources_table.php
+++ b/database/migrations/2025_02_12_120510_create_resources_table.php
@@ -25,7 +25,8 @@ return new class extends Migration
             $table->string('description');
             $table->string('url');
             $table->enum('category', ['Node', 'React', 'Angular', 'JavaScript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']);
-            $table->enum('theme', ['All', 'Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router']);
+            //$table->set('tags', ['Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router'])->nullable();
+            $table->json('tags')->nullable(); // Options are restricted in Form Request (as defined in table tags)
             $table->enum('type', ['Video', 'Cursos', 'Blog']);
             $table->integer('bookmark_count')->default(0);
             $table->integer('like_count')->default(0);

--- a/database/migrations/2025_02_12_120510_create_resources_table.php
+++ b/database/migrations/2025_02_12_120510_create_resources_table.php
@@ -25,7 +25,6 @@ return new class extends Migration
             $table->string('description');
             $table->string('url');
             $table->enum('category', ['Node', 'React', 'Angular', 'JavaScript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']);
-            //$table->set('tags', ['Components', 'UseState & UseEffect', 'Eventos' , 'Renderizado condicional', 'Listas', 'Estilos', 'Debugging', 'React Router'])->nullable();
             $table->json('tags')->nullable(); // Options are restricted in Form Request (as defined in table tags)
             $table->enum('type', ['Video', 'Cursos', 'Blog']);
             $table->integer('bookmark_count')->default(0);

--- a/database/migrations/2025_02_12_120510_create_resources_table.php
+++ b/database/migrations/2025_02_12_120510_create_resources_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->string('description');
             $table->string('url');
             $table->enum('category', ['Node', 'React', 'Angular', 'JavaScript', 'Java', 'Fullstack PHP', 'Data Science', 'BBDD']);
-            $table->json('tags')->nullable(); // Options are restricted in Form Request (as defined in table tags)
+            $table->json('tags')->nullable(); // Options must be restricted in Form Request (as defined in table tags)
             $table->enum('type', ['Video', 'Cursos', 'Blog']);
             $table->integer('bookmark_count')->default(0);
             $table->integer('like_count')->default(0);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             RoleSeeder::class,
+            TagSeeder::class,
             ResourceSeeder::class,
             BookmarkSeeder::class,
             LikeSeeder::class

--- a/database/seeders/ResourceSeeder.php
+++ b/database/seeders/ResourceSeeder.php
@@ -6,6 +6,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\Resource;
 
 class ResourceSeeder extends Seeder
 {
@@ -14,6 +15,6 @@ class ResourceSeeder extends Seeder
      */
     public function run(): void
     {
-        \App\Models\Resource::factory(10)->create();
+        Resource::factory(10)->create();
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -1,0 +1,78 @@
+<?php
+declare (strict_types= 1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Tag;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $tags = [
+            'unitary-testing',
+            'tdd',
+            'oop',
+            'debugging',
+            'rendering',
+            'styling-css',
+            'hooks',
+            'components',
+            'fragments',
+            'props',
+            'lists-keys',
+            'modules',
+            'events',
+            'dependencies',
+            'mongodb',
+            'postgresql',
+            'firebase',
+            'aws',
+            'azure',
+            'vercel',
+            'github',
+            'basico',
+            'intermedio',
+            'avanzado',
+            'sintaxis',
+            'estructuras-de-datos',
+            'algoritmos',
+            'programacion-orientada-a-objetos',
+            'programacion-funcional',
+            'testing',
+            'ci-cd',
+            'version-control',
+            'mvc',
+            'microservicios',
+            'ddd',
+            'solid',
+            'rest',
+            'graphql',
+            'autenticacion',
+            'autorizacion',
+            'sql',
+            'nosql',
+            'orm',
+            'docker',
+            'kubernetes',
+            'serverless',
+            'cloud',
+            'seguridad',
+            'rendimiento',
+            'optimizacion',
+            'documentacion',
+            'code-review'
+        ];
+        
+        foreach ($tags as $tag) {
+            Tag::create([
+                'name' => $tag,
+            ]);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,3 +34,6 @@ Route::post('/likes', [LikeController::class,'createStudentLike'])->name('like.c
 Route::delete('/likes', [LikeController::class,'deleteStudentLike'])->name('like.delete');
 
 Route::get('/tags', [TagController::class, 'index'])->name('tags'); // retrieves all tags
+
+Route::get('/tags/frequency', [TagController::class, 'getTagsFrequency'])->name('tags.frequency'); // retrieves frequencies of tags used in resources
+// This last endpoint will be necessary for filtering since allowed tags will change over time...

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,4 +33,4 @@ Route::post('/likes', [LikeController::class,'createStudentLike'])->name('like.c
 
 Route::delete('/likes', [LikeController::class,'deleteStudentLike'])->name('like.delete');
 
-Route::get('/tags', [TagController::class, 'index'])->name('tags.index'); // retrieves all tags
+Route::get('/tags', [TagController::class, 'index'])->name('tags'); // retrieves all tags

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\RoleController;
 use App\Http\Controllers\ResourceController;
 use App\Http\Controllers\ResourceEditController;
 use App\Http\Controllers\LikeController;
+use App\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
 
 
@@ -31,3 +32,5 @@ Route::get('/likes/{github_id}', [LikeController::class,'getStudentLikes'])->nam
 Route::post('/likes', [LikeController::class,'createStudentLike'])->name('like.create');
 
 Route::delete('/likes', [LikeController::class,'deleteStudentLike'])->name('like.delete');
+
+Route::get('/tags', [TagController::class, 'index'])->name('tags.index'); // retrieves all tags

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -801,14 +801,14 @@
                 }
             }
         },
-        "/tags": {
+        "/api/tags": {
             "get": {
                 "tags": [
                     "Tags"
                 ],
                 "summary": "Get all tags",
                 "description": "Tags used in resources",
-                "operationId": "d39568b98d6f2fa018ae4ac70504ae70",
+                "operationId": "4d0f4baf9e6fa992c0d85fbf140ebf17",
                 "responses": {
                     "200": {
                         "description": "A list of tags",
@@ -819,6 +819,28 @@
                                     "items": {
                                         "$ref": "#/components/schemas/Tag"
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tags/frequency": {
+            "get": {
+                "tags": [
+                    "Tags"
+                ],
+                "summary": "Get tag frequencies",
+                "description": "Frequencies of tags used in resources",
+                "operationId": "7ba6cfbebeddc69fac4a37ad216924ab",
+                "responses": {
+                    "200": {
+                        "description": "An object with tag names as keys and frequencies as values",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
                                 }
                             }
                         }

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -424,7 +424,6 @@
                                     "description",
                                     "url",
                                     "category",
-                                    "theme",
                                     "type"
                                 ],
                                 "properties": {
@@ -468,21 +467,13 @@
                                         ],
                                         "example": "React"
                                     },
-                                    "theme": {
-                                        "description": "Theme of the resource",
-                                        "type": "string",
-                                        "enum": [
-                                            "All",
-                                            "Components",
-                                            "UseState & UseEffect",
-                                            "Eventos",
-                                            "Renderizado condicional",
-                                            "Listas",
-                                            "Estilos",
-                                            "Debugging",
-                                            "React Router"
-                                        ],
-                                        "example": "Components"
+                                    "tags": {
+                                        "description": "Array of tags validated against available options (nullable)",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "example": "oop"
+                                        }
                                     },
                                     "type": {
                                         "description": "Type of the resource",
@@ -546,9 +537,9 @@
                                                     "The category field is required.",
                                                     "The selected category is invalid."
                                                 ],
-                                                "theme": [
-                                                    "The theme field is required.",
-                                                    "The selected theme is invalid."
+                                                "tags": [
+                                                    "The tags field must be an array of strings.",
+                                                    "The selected tags are invalid."
                                                 ],
                                                 "type": [
                                                     "The type field is required.",
@@ -704,6 +695,31 @@
                     }
                 }
             }
+        },
+        "/tags": {
+            "get": {
+                "tags": [
+                    "Tags"
+                ],
+                "summary": "Get all tags",
+                "description": "Tags used in resources",
+                "operationId": "d39568b98d6f2fa018ae4ac70504ae70",
+                "responses": {
+                    "200": {
+                        "description": "A list of tags",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Tag"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -779,12 +795,12 @@
                         "type": "integer",
                         "example": 12345
                     },
-                    "description": {
+                    "title": {
                         "type": "string",
                         "example": "Lorem Ipsum ...",
                         "nullable": true
                     },
-                    "title": {
+                    "description": {
                         "type": "string",
                         "example": "Lorem Ipsum ...",
                         "nullable": true
@@ -809,20 +825,17 @@
                         ],
                         "example": "Node"
                     },
-                    "theme": {
-                        "type": "string",
-                        "enum": [
-                            "All",
-                            "Components",
-                            "UseState & UseEffect",
-                            "Eventos",
-                            "Renderizado condicional",
-                            "Listas",
-                            "Estilos",
-                            "Debugging",
-                            "React Router"
-                        ],
-                        "example": "All"
+                    "tags": {
+                        "description": "Array of tags",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "kubernetes",
+                            "sql",
+                            "azure"
+                        ]
                     },
                     "type": {
                         "type": "string",
@@ -869,6 +882,31 @@
                     }
                 },
                 "type": "object"
+            },
+            "Tag": {
+                "title": "Tag",
+                "description": "Tags used in resources",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "debugging"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-03-17T19:23:41.000000Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-03-17T19:23:41.000000Z"
+                    }
+                },
+                "type": "object"
             }
         }
     },
@@ -888,6 +926,10 @@
         {
             "name": "Roles",
             "description": "Roles"
+        },
+        {
+            "name": "Tags",
+            "description": "Tags"
         }
     ]
 }

--- a/tests/Feature/CreateResourceTest.php
+++ b/tests/Feature/CreateResourceTest.php
@@ -16,8 +16,12 @@ class CreateResourceTest extends TestCase
 
     private function GetResourceData(): array
     {
-        Role::factory(10)->create();
-        return Resource::factory()->raw(); 
+        $role = Role::factory()->create(['role' => 'student']);
+
+        return Resource::factory()->raw([
+            'github_id' => $role->github_id,
+            //'tags' => null
+        ]);
     }
 
     public function testItCanCreateAResource(): void

--- a/tests/Feature/TagControllerTest.php
+++ b/tests/Feature/TagControllerTest.php
@@ -1,20 +1,70 @@
 <?php
-
 declare (strict_types= 1);
 
 namespace Tests\Feature;
 
+use App\Models\Resource;
+use App\Models\Role;
 use App\Models\Tag;
 use Tests\TestCase;
 
 class TagControllerTest extends TestCase
 {
-    /**
-     * A basic feature test example.
-     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $tags = [
+            'tag-one',
+            'tag-two',
+            'tag-three'
+        ];
+
+        foreach ($tags as $tag) {
+            Tag::create([
+                'name' => $tag
+            ]);
+        }
+
+        Role::factory()->create([
+            'github_id' => 9871315,
+            'role' => 'student'
+        ]);
+
+        Resource::factory()->create([
+            'github_id' => 9871315,
+            'tags' => ['tag-one']
+        ]);
+
+        Resource::factory()->create([
+            'github_id' => 9871315,
+            'tags' => ['tag-one', 'tag-two']
+        ]);
+
+        Resource::factory()->create([
+            'github_id' => 9871315,
+            'tags' => ['tag-one', 'tag-two', 'tag-three']
+        ]);
+      
+    }
+    
     public function testCanGetTagsList(): void
     {
         $response = $this->get(route('tags'));
         $response->assertStatus(200);
+        $response->assertJsonFragment(['name' => 'tag-one']);
+        $response->assertJsonFragment(['name' => 'tag-two']);
+        $response->assertJsonFragment(['name' => 'tag-three']);
+    }
+
+    public function testCanGetTagsFrequency(): void
+    {
+        $response = $this->get(route('tags.frequency'));
+        $response->assertStatus(200)
+            ->assertJson([ 
+                'tag-one' => 3,
+                'tag-two' => 2,
+                'tag-three' => 1
+            ]);
     }
 }

--- a/tests/Feature/TagControllerTest.php
+++ b/tests/Feature/TagControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare (strict_types= 1);
+
+namespace Tests\Feature;
+
+use App\Models\Tag;
+use Tests\TestCase;
+
+class TagControllerTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     */
+    public function testCanGetTagsList(): void
+    {
+        $response = $this->get(route('tags'));
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Resource model : theme attribute (enum) has been replaced by tags attribute (array of strings).
Tag model (new) : seeded. 'name' has unique constrain.

Endpoint : Route::get('/tags', [TagController::class, 'index'])->name('tags'); // retrieves all tags
http://localhost:8000/api/tags/
https://ita-wiki-backend-production.up.railway.app/api/tags

There is a second endpoint forseeeing the use of 'tag' for resources filtering... Tags used in old resources could no longer exist in allowed names of actual tags table...