### PR TITLE
Feature/endpoint tags by category

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -108,7 +108,25 @@ class TagController extends Controller
 
         return response()->json($frequencies, 200);
     }
-
+/**
+     * @OA\Get(
+     *     path="/api/tags/by-category",
+     *     summary="Get tag IDs grouped by category",
+     *     tags={"Tags"},
+     *     description="Returns the IDs of tags used in resources, grouped by resource category. This does not require a pivot table and is based on matching tag names from a JSON column.",
+     *     @OA\Response(
+     *         response=200,
+     *         description="An object with category names as keys and arrays of tag IDs as values",
+     *         @OA\JsonContent(
+     *              type="object",
+     *              example={
+     *                  "Fullstack PHP": {1, 5, 6},
+     *                  "React": {3, 7}
+     *              }
+     *         )
+     *     )
+     * )
+     */
     public function getCategoryTagsId () : JsonResponse
     {
          $resourcesByCategory = Resource::all()->groupBy('category');

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Tag;
 use App\Models\Resource;
+use Illuminate\Http\JsonResponse;
+
 
 class TagController extends Controller
 {
@@ -106,4 +108,29 @@ class TagController extends Controller
 
         return response()->json($frequencies, 200);
     }
+
+    public function getCategoryTagsId () : JsonResponse
+    {
+         $resourcesByCategory = Resource::all()->groupBy('category');
+        $tagsByCategory = [];
+
+    foreach ($resourcesByCategory as $category => $resources) {
+        $tagNames = $resources
+            ->pluck('tags')     
+            ->filter()
+            ->flatten()        
+            ->unique()
+            ->values();
+            
+
+        $tagIds = Tag::whereIn('name', $tagNames)->pluck('id')->all();
+        
+        $tagsByCategory[$category] = $tagIds;
+    }
+
+    return response()->json($tagsByCategory, 200);
+
+    }
+
+    
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -62,4 +62,6 @@ class Resource extends Model
         return $this->hasMany(Like::class);
     }
 
+  
+
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -28,4 +28,6 @@ class Tag extends Model
     protected $casts = [
         'name' => 'string',
     ];
+
+  
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,7 +41,7 @@ Route::get('/tags/frequency', [TagController::class, 'getTagsFrequency'])->name(
 
 Route::get('/tags/category-frequency', [TagController::class, 'getCategoryTagsFrequency'])->name('category.tags.frequency');
 
-
+Route::get('/tags/by-category', [TagController::class, 'getCategoryTagsId'])->name('category.tags.id');
 
 
 // FEATURE FLAGS ENDPOINTS

--- a/tests/Feature/TagControllerTest.php
+++ b/tests/Feature/TagControllerTest.php
@@ -68,4 +68,10 @@ class TagControllerTest extends TestCase
         $response = $this->get(route('category.tags.frequency'));
         $response->assertStatus(200);
     }
+
+      public function testCanGetCategoryTagsId(): void
+    {
+        $response = $this->get('/api/tags/by-category');
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
Nuevo endpoint api/tags/by-category. Sigue la misma logica que el anterior endpoint de tags/category-frequency.
En este caso el endpoint nos devuelve un objeto con la clave siendo la categoria y un array con los ids de los tags.
Ejemplo: 

example={
     *                  "Fullstack PHP": {1, 5, 6},
     *                  "React": {3, 7}
     *              }