### PR TITLE
feat: new endpoint with test and notations

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -4,8 +4,9 @@ declare (strict_types= 1);
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\StoreResourceRequest;
 use App\Models\Resource;
+use App\Http\Requests\StoreResourceRequest;
+use App\Http\Requests\StoreResourceV2Request;
 
     /**
      * @OA\Info(
@@ -21,9 +22,11 @@ class ResourceController extends Controller
     /**
      * @OA\Post(
      *     path="/api/resources",
-     *     summary="Create a new resource",
+     *     summary="Create a new resource (deprecated, use /api/v2/resources instead)",
+     *      deprecated= true,
      *     tags={"Resources"},
-     *     description="Creates a new resource and returns the created resource",
+     *     description="This endpoint is deprecated and will be removed soon. Please use the new endpoint /api/v2/resources instead.
+     *      Creates a new resource and returns the created resource",
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
@@ -62,6 +65,46 @@ class ResourceController extends Controller
      */
     
     public function store(StoreResourceRequest $request)
+    {
+        $validated = $request->validated();
+        $resource = Resource::create($validated);
+        return response()->json($resource, 201);
+    }
+
+
+
+/**
+ * @OA\Post(
+ *     path="/api/createResources",
+ *     summary="Create a new resource using tag IDs",
+ *     tags={"Resources"},
+ *     description="Creates a resource. This version expects an array of tag IDs instead of tag names.",
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             required={"github_id", "title", "url", "category", "type"},
+ *             @OA\Property(property="github_id", type="integer", example=123456),
+ *             @OA\Property(property="title", type="string", example="Aprende Laravel en 10 días"),
+ *             @OA\Property(property="description", type="string", example="Curso completo de Laravel para principiantes."),
+ *             @OA\Property(property="url", type="string", format="url", example="https://miweb.com/laravel"),
+ *             @OA\Property(property="category", type="string", example="Fullstack PHP"),
+ *             @OA\Property(property="tags", type="array", @OA\Items(type="integer"), example={1, 3, 5}),
+ *             @OA\Property(property="type", type="string", example="Video")
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=201,
+ *         description="Resource created successfully",
+ *         @OA\JsonContent(ref="#/components/schemas/Resource")
+ *     ),
+ *     @OA\Response(
+ *         response=422,
+ *         description="Validation error"
+ *     )
+ * )
+ */
+
+     public function storeResource(StoreResourceV2Request $request)
     {
         $validated = $request->validated();
         $resource = Resource::create($validated);

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -75,7 +75,7 @@ class ResourceController extends Controller
 
 /**
  * @OA\Post(
- *     path="/api/createResources",
+ *     path="/api/v2/resources",
  *     summary="Create a new resource using tag IDs",
  *     tags={"Resources"},
  *     description="Creates a resource. This version expects an array of tag IDs instead of tag names.",

--- a/app/Http/Requests/StoreResourceV2Request.php
+++ b/app/Http/Requests/StoreResourceV2Request.php
@@ -9,10 +9,10 @@ use Illuminate\Validation\Rule;
 use App\Rules\GithubIdRule;
 use App\Rules\RoleStudentRule;
 
-class StoreResourceRequest extends FormRequest
+class StoreResourceV2Request extends FormRequest
 {
 
-    //to be deprecated in the future, use StoreResourceV2Request instead
+    
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -38,7 +38,7 @@ class StoreResourceRequest extends FormRequest
             'url' => ['required', 'url'],
             'category' => ['required', 'string', 'in:Node,React,Angular,JavaScript,Java,Fullstack PHP,Data Science,BBDD'],
             'tags' => ['nullable', 'array', 'max:5'],
-            'tags.*' => ['string', 'distinct', Rule::exists('tags', 'name')],
+            'tags.*' => ['integer', 'distinct', Rule::exists('tags', 'id')],
             'type' =>['required', 'string', 'in:Video,Cursos,Blog']
         ];
     }  

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::post('/resources', [ResourceController::class, 'store'])->name('resources.store');
 
+Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name('resources.store.v2');
+
 Route::get('/resources', [ResourceController::class, 'index'])->name('resources');
 
 Route::post('/login', [RoleController::class, 'getRoleByGithubId'])->name('login');

--- a/tests/Feature/CreateResourceTest.php
+++ b/tests/Feature/CreateResourceTest.php
@@ -4,11 +4,12 @@ declare (strict_types= 1);
 
 namespace Tests\Feature;
 
-use App\Models\Resource;
+use App\Models\Tag;
+use Tests\TestCase;
 use App\Models\Role;
+use App\Models\Resource;
 use Illuminate\Foundation\Testing\WithFaker;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\TestCase;
 
 class CreateResourceTest extends TestCase
 {
@@ -22,10 +23,30 @@ class CreateResourceTest extends TestCase
             'github_id' => $role->github_id,
             //'tags' => null
         ]);
+       
+    }
+
+    private function GetResourceDataTagsId(): array
+    {
+        $role = Role::factory()->create(['role' => 'student']);
+        $tagIds = Tag::inRandomOrder()->take(3)->pluck('id')->toArray();
+
+        return Resource::factory()->raw([
+            'github_id' => $role->github_id,
+            'tags' => $tagIds // Assuming these IDs exist in the tags table
+        ]);
+    }
+
+    public function testItCanCreateAResourceWithTagsId(): void
+    {
+        $response = $this->postJson(route('resources.store.v2'), $this->GetResourceDataTagsId());
+
+        $response->assertStatus(201);
     }
 
     public function testItCanCreateAResource(): void
     {
+        
         $response = $this->postJson(route('resources.store'), $this->GetResourceData());
 
         $response->assertStatus(201);
@@ -53,6 +74,7 @@ class CreateResourceTest extends TestCase
         });
     }
 
+  
         
     public static function resourceValidationProvider(): array
     {


### PR DESCRIPTION
Nuevo endpoint  post/v2/resource igual al anterior post/resource, con la diferencia que este procesa tags_ids y no strings. Es decir, ahora el frontend puede enviar los ids de las tags y no los nombres de las tags a la hora de crear un recurso.

La próxima semana se eliminará el anterior endpoint que veniamos usando para crear recursos.