### PR TITLE
Feature/endpoint get resource

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -135,6 +135,29 @@ class ResourceController extends Controller
         return response()->json($resources, 200);
     }
 
+    /**
+     * @OA\Get(
+     *  path="/api/v2/resources",
+     *  summary="Search resources by title, description, URL, category, or type",
+     *  tags={"Resources"},
+     *  description="Returns resources matching the search term or all resources if no search term is provided",
+     *  @OA\Parameter(
+     *      name="search",
+     *      in="query",
+     *      required=false,
+     *      @OA\Schema(type="string", example="JavaScript")
+     *  ),
+     *  @OA\Response(
+     *      response=200,
+     *      description="List of resources matching the search term or all resources if no search term is provided",
+     *      @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/Resource"))
+     *  ),
+     *  @OA\Response(
+     *      response=404,
+     *      description="No resources found"
+     *  )
+     * )
+     */
     public function showResource (ShowResourceRequest $request){
 
         $validated= $request->validated();

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -136,9 +136,11 @@ class ResourceController extends Controller
     }
 
     public function showResource (ShowResourceRequest $request){
+
         $validated= $request->validated();
-        $searchTerm = $validated['search'];
+        $searchTerm = $validated['search'] ?? null;
         
+        if ($searchTerm && trim($searchTerm) !== '') {
         $resources = Resource::where('title', 'like', '%' . $searchTerm . '%')
             ->orWhere('description', 'like', '%' . $searchTerm . '%')
             ->orWhere('url', 'like', '%' . $searchTerm . '%')
@@ -146,10 +148,16 @@ class ResourceController extends Controller
             ->orWhere('type', 'like', '%' . $searchTerm . '%')
             ->get();
 
-            if($resources->isEmpty()) {
-                return response()->json(['message' => 'No resources found'], 404);
-            }
+        if ($resources->isEmpty()) {
+            return response()->json(['message' => 'No resources found'], 404);
+        }
+
         return response()->json($resources, 200);
+    }
+
+    // Si no hay search, devuelve todos
+    $resources = Resource::all();
+    return response()->json($resources, 200);
 
 
     }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -4,6 +4,7 @@ declare (strict_types= 1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ShowResourceRequest;
 use App\Models\Resource;
 use App\Http\Requests\StoreResourceRequest;
 use App\Http\Requests\StoreResourceV2Request;
@@ -132,6 +133,25 @@ class ResourceController extends Controller
     {
         $resources = Resource::all();
         return response()->json($resources, 200);
+    }
+
+    public function showResource (ShowResourceRequest $request){
+        $validated= $request->validated();
+        $searchTerm = $validated['search'];
+        
+        $resources = Resource::where('title', 'like', '%' . $searchTerm . '%')
+            ->orWhere('description', 'like', '%' . $searchTerm . '%')
+            ->orWhere('url', 'like', '%' . $searchTerm . '%')
+            ->orWhere('category', 'like', '%' . $searchTerm . '%')
+            ->orWhere('type', 'like', '%' . $searchTerm . '%')
+            ->get();
+
+            if($resources->isEmpty()) {
+                return response()->json(['message' => 'No resources found'], 404);
+            }
+        return response()->json($resources, 200);
+
+
     }
 
 }

--- a/app/Http/Requests/ShowResourceRequest.php
+++ b/app/Http/Requests/ShowResourceRequest.php
@@ -24,7 +24,7 @@ class ShowResourceRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'search' => 'required|string|max:30|regex:/^[a-zA-Z0-9\s]+$/',
+            'search' => 'nullable|string|max:30|regex:/^[a-zA-Z0-9\s]+$/',
             //
         ];
     }
@@ -32,7 +32,6 @@ class ShowResourceRequest extends FormRequest
     public function messages()
     {
         return [
-            'search.required'=> 'Search cannot be empty',
             'search.max'=> 'Search is too long'
         ];
     }

--- a/app/Http/Requests/ShowResourceRequest.php
+++ b/app/Http/Requests/ShowResourceRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare (strict_types= 1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowResourceRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/ShowResourceRequest.php
+++ b/app/Http/Requests/ShowResourceRequest.php
@@ -13,7 +13,7 @@ class ShowResourceRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -24,7 +24,16 @@ class ShowResourceRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'search' => 'required|string|max:30|regex:/^[a-zA-Z0-9\s]+$/',
             //
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'search.required'=> 'Search cannot be empty',
+            'search.max'=> 'Search is too long'
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,8 @@ Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name
 
 Route::get('/resources', [ResourceController::class, 'index'])->name('resources');
 
+Route::get('/resources', [ResourceController::class, 'showResource'])->name('showResource');
+
 Route::post('/login', [RoleController::class, 'getRoleByGithubId'])->name('login');
 
 Route::put('/resources/{resource}', [ResourceEditController::class, 'update'])->name('resources.update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,7 +17,7 @@ Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name
 
 Route::get('/resources', [ResourceController::class, 'index'])->name('resources');
 
-Route::get('/resources', [ResourceController::class, 'showResource'])->name('showResource');
+Route::get('v2/resources', [ResourceController::class, 'showResource'])->name('showResource');
 
 Route::post('/login', [RoleController::class, 'getRoleByGithubId'])->name('login');
 

--- a/tests/Feature/ShowResourceTest.php
+++ b/tests/Feature/ShowResourceTest.php
@@ -13,9 +13,9 @@ class ShowResourceTest extends TestCase
     /**
      * A basic feature test example.
      */
-    public function test_example(): void
+    public function test_user_can_search_for_resources(): void
     {
-        $response = $this->get('/');
+        $response = $this->get('/api/resources?search=javascript'); 
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/ShowResourceTest.php
+++ b/tests/Feature/ShowResourceTest.php
@@ -15,7 +15,7 @@ class ShowResourceTest extends TestCase
      */
     public function test_user_can_search_for_resources(): void
     {
-        $response = $this->get('/api/resources?search=javascript'); 
+        $response = $this->get('/api/v2/resources?search=javascript'); 
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/ShowResourceTest.php
+++ b/tests/Feature/ShowResourceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare (strict_types= 1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ShowResourceTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     */
+    public function test_example(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Nuevo endpoint para obtener recursos con parámetros de búsqueda. He introducido en el mismo método la opción de no enviar ningún parámetro y en este caso devolvería todos los recursos sin filtrar para que se pueda quizás utilizar en otras partes del código. 
La búsqueda la realiza en "title, description, URL, category, or type".