### PR TITLE
Implementacionde github Oauth

### DIFF
--- a/app/Http/Controllers/GitHubAuthController.php
+++ b/app/Http/Controllers/GitHubAuthController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Laravel\Socialite\Facades\Socialite;
+use Illuminate\Http\Request;
+
+class GitHubAuthController extends Controller
+{
+    public function redirect()
+    {
+        return Socialite::driver('github')->stateless()->redirect();
+    }
+
+    public function callback(Request $request)
+    {
+        $githubUser = Socialite::driver('github')->stateless()->user();
+
+        return response()->json([
+            'github_id' => $githubUser->getId(),
+            'node_id' => $githubUser->user['node_id'] ?? null,
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": "^8.2",
         "darkaonline/l5-swagger": "^9.0",
         "laravel/framework": "^11.31",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9", 
+        "laravel/socialite": "^5.8"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'Laravel'),
+    'name' => env('ITA_wiki', 'Laravel'),
 
     /*
     |--------------------------------------------------------------------------
@@ -121,6 +121,12 @@ return [
     'maintenance' => [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
+    ],
+    'providers' => [
+      Laravel\Socialite\SocialiteServiceProvider::class,
+    ],
+    'aliases' => [
+        'Socialite' => Laravel\Socialite\Facades\Socialite::class,
     ],
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -1,5 +1,5 @@
 <?php
-
+$isProd = env('APP_ENV') === 'production';
 return [
 
     /*
@@ -13,6 +13,12 @@ return [
     | a conventional file to locate the various service credentials.
     |
     */
+    
+    'github' => [
+    'client_id' => env($isProd ? 'GITHUB_CLIENT_ID_PROD' : 'GITHUB_CLIENT_ID_LOCAL'),
+    'client_secret' => env($isProd ? 'GITHUB_CLIENT_SECRET_PROD' : 'GITHUB_CLIENT_SECRET_LOCAL'),
+    'redirect' => env($isProd ? 'GITHUB_REDIRECT_URI_PROD' : 'GITHUB_REDIRECT_URI_LOCAL'),
+    ],
 
     'postmark' => [
         'token' => env('POSTMARK_TOKEN'),

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,7 +9,10 @@ use App\Http\Controllers\ResourceEditController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\TagController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GitHubAuthController;
 
+Route::get('/auth/github/redirect', [GitHubAuthController::class, 'redirect']);
+Route::get('/auth/github/callback', [GitHubAuthController::class, 'callback']);
 
 Route::post('/resources', [ResourceController::class, 'store'])->name('resources.store');
 


### PR DESCRIPTION
Se ha implementado Oauth github, para trabajar tanto con node_id y con github_id hasta que se retire totalmente de la apalicacion. 
- Authcontroller
- Instalacion de socialite

Con esto ya hay un login GitHub funcional que:
- No guarda usuarios.
- No gestiona sesiones ni cookies.
- Solo devuelve github_id y node_id.

