### PR TITLE
Add tests for GitHub auth error handling

### DIFF
--- a/tests/Feature/GitHubAuthErrorTest.php
+++ b/tests/Feature/GitHubAuthErrorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Laravel\Socialite\Facades\Socialite;
+use Mockery;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class GitHubAuthErrorTest extends TestCase
+{
+    public function test_github_callback_returns_500_without_internal_details_on_network_error()
+    {
+        $mockDriver = Mockery::mock('Laravel\Socialite\Two\GithubProvider');
+        $mockDriver->shouldReceive('user')->andThrow(new RequestException('Network error', new \GuzzleHttp\Psr7\Request('GET', 'test')));
+        Socialite::shouldReceive('driver')->with('github')->andReturn($mockDriver);
+
+        $response = $this->get('/api/auth/github/callback');
+
+        $response->assertStatus(500);
+
+        $response->assertDontSee('Stack trace');
+        $response->assertDontSee('Exception');
+        $response->assertDontSee('Guzzle');
+        $response->assertJsonMissing(['exception', 'file', 'trace']);
+    }
+
+
+    public function test_github_callback_returns_500_without_internal_details_on_generic_exception()
+    {
+        $mockDriver = Mockery::mock('Laravel\Socialite\Two\GithubProvider');
+        $mockDriver->shouldReceive('user')->andThrow(new \Exception('Unexpected error'));
+        Socialite::shouldReceive('driver')->with('github')->andReturn($mockDriver);
+
+        $response = $this->get('/api/auth/github/callback');
+
+        $response->assertStatus(500);
+        $response->assertDontSee('Stack trace');
+        $response->assertDontSee('Exception');
+        $response->assertJsonMissing(['exception', 'file', 'trace']);
+    }
+} 


### PR DESCRIPTION
Este archivo de tests verifica el manejo de errores en el callback de autenticación de GitHub en la API. Los tests cubren los siguientes escenarios:
Error de red de GitHub (network error):
Simula un fallo de red al intentar obtener el usuario desde GitHub y verifica que la API responde con un error 500, sin exponer detalles internos como el stack trace o información sensible de la excepción.
Excepción genérica:
Simula una excepción inesperada durante el proceso de autenticación (Error de programación, o en el formato de los datos recibidos de GitHub, bug en la lógica de autenticación de la app, variable de entorno mal configurada o faltante, etc.. ) y verifica que la respuesta también sea un error 500, sin mostrar detalles internos de la excepción.