### PR TITLE
Column github_id added to model User and related files

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'github_id',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -25,6 +25,7 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
+            'github_id' => fake()->numberBetween(1, 999999999),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),

--- a/database/migrations/2025_07_21_185213_add_github_id_to_users_table.php
+++ b/database/migrations/2025_07_21_185213_add_github_id_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare (strict_types= 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->bigInteger('github_id')->unsigned()->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            UserSeeder::class,
             RoleSeeder::class,        RoleNodeSeeder::class,      // for node_id transition
             TagSeeder::class,         TagNodeSeeder::class,       //for node_id transition
             ResourceSeeder::class,    ResourceNodeSeeder::class,  // for node_id transition
@@ -27,9 +28,5 @@ class DatabaseSeeder extends Seeder
             TechnicalTestSeeder::class,
         ]);
     
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+       User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'github_id' => '999999999',
+        ]);
+
+        User::factory(20)->create();
+    }
+}
+

--- a/tests/Feature/UserModelTest.php
+++ b/tests/Feature/UserModelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UserModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testUserCanBeCreatedWithGithubId(): void
+    {
+        $user = User::factory()->create([
+            'github_id' => '123456789'
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'github_id' => '123456789',
+            'email' => $user->email
+        ]);
+    }
+
+    public function testGithubIdIsAccessible(): void
+    {
+        $githubId = '987654321';
+        $user = User::factory()->create(['github_id' => $githubId]);
+
+        $this->assertEquals($githubId, $user->github_id);
+    }
+
+}


### PR DESCRIPTION
Se añade migración para crear la columna **github_id** en la tabla **Users** de forma que Spatie pueda utilizarla cuando se instale.
Se modifican los ficheros relacionados: **model/User** y **UserFactory**,   y se crean **UserSeeder** y **UserModelTest**