### PR TITLE
WIP Register user method. Pending to have github_id&name merged to complete work

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Passport\HasApiTokens;
+
+class AuthController extends Controller
+{
+    //User register antiguamente createRole en RoleController
+    public function register(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+          //  'github_id' =>'required|integer|min:1|max:9999999999|unique:users',
+          //  'github_user_name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:8|confirmed',
+           // 'password_confirmation' => 'required|same:password',
+        ]);
+        
+        $user = User::create([
+            'name' => $request->name,
+          //  'github_id' => $request->github_id,
+          //  'github_user_name' => $request->github_user_name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        return response()->json([
+            'message' => 'User created successfully',
+        ], 201);         
+    }
+}

--- a/app/Http/Controllers/TechnicalTestController.php
+++ b/app/Http/Controllers/TechnicalTestController.php
@@ -1,6 +1,9 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace App\Http\Controllers;
+
 use App\Http\Requests\IndexTechnicalTestRequest;
 use App\Http\Requests\StoreTechnicalTestRequest;
 use App\Models\TechnicalTest;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
 use App\Http\Controllers\TagController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\RoleController;
@@ -15,6 +16,12 @@ use App\Http\Controllers\Api\BookmarkNodeController;
 
 Route::get('/auth/github/redirect', [GitHubAuthController::class, 'redirect']);
 Route::get('/auth/github/callback', [GitHubAuthController::class, 'callback']);
+
+// Public routes
+Route::post('/register', [AuthController::class, 'register'])->name('users.register');
+
+
+// 
 Route::post('/resources', [ResourceController::class, 'store'])->name('resources.store');
 Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name('resources.store.v2');
 Route::get('/resources', [ResourceController::class, 'index'])->name('resources');

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+
+class AuthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {   
+        parent::setUp();  
+        User::truncate();
+    }
+
+    protected function validUserData($overrides = [])
+    {
+        return array_merge([
+            'name' => 'Testing User',
+        //    'github_id' => 111111111,   pendiente del merge con pr para añadir estos campos a user
+        //    'github_user_name' => 'testing github name',
+            'email' => 'testing@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ], $overrides);
+    }
+
+    public function test_register_creates_user_with_correct_data()
+    {
+        $data = $this->validUserData();
+
+        $response = $this->postJson('/api/register', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment([
+                'message' => 'User created successfully',
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'name' => $data['name'],
+            // 'github_id' => $data['github_id'],
+            // 'github_user_name' => $data['github_user_name'],
+            'email' => $data['email'],
+        ]);
+
+        $user = User::where('email', $data['email'])->first();
+        $this->assertTrue(Hash::check($data['password'], $user->password));
+    }
+
+    public function test_register_requires_all_fields()
+    {
+        $response = $this->postJson('/api/register', []);
+
+     // dump($response->getStatusCode());
+     // dump($response->json());    
+
+        $response->assertStatus(422);
+        $data = $response->json();
+
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayHasKey('email', $data);
+        $this->assertArrayHasKey('password', $data);
+        // $this->assertArrayHasKey('github_id', $data);
+        // $this->assertArrayHasKey('github_user_name', $data);
+        
+        $this->assertEquals(['The name field is required.'], $data['name']);
+        $this->assertEquals(['The email field is required.'], $data['email']);
+        $this->assertEquals(['The password field is required.'], $data['password']);
+        //$this->assertEquals(['The github_id field is required.'], $data['github_id']);
+        //$this->assertEquals(['The github_user_name field is required.'], $data['github_user_name']);       
+    }
+
+    public function test_register_fails_with_duplicate_email()
+    {
+        User::factory()->create(['email' => 'testing@example.com']);
+        $data = $this->validUserData();
+
+        $response = $this->postJson('/api/register', $data);
+                
+        $response->assertStatus(422);
+        $data = $response->json();
+        
+        $this->assertArrayHasKey('email', $data);
+        $this->assertEquals(['The email has already been taken.'], $data['email']);
+
+    }
+
+    public function test_register_fails_with_password_confirmation_mismatch()
+    {
+        $data = $this->validUserData(['password_confirmation' => 'wrongpassword']);
+        $response = $this->postJson('/api/register', $data);
+
+        $response->assertStatus(422);
+        $data = $response->json();
+        
+        $this->assertArrayHasKey('password', $data);
+        $this->assertEquals(['The password field confirmation does not match.'], $data['password']);            
+    }
+
+}

--- a/tests/Feature/TechnicalTestIndexTest.php
+++ b/tests/Feature/TechnicalTestIndexTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Tests\Feature;
 
 use App\Models\TechnicalTest;
@@ -12,7 +14,6 @@ use Tests\TestCase;
 class TechnicalTestIndexTest extends TestCase
 {
     use RefreshDatabase;
-
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Se ha creado metodo register en AuthController para registrar los nuevos usuarios.
Este método se crea para sustituir el método **CreateRole** en **RoleController** con el objetivo de adaptar la tabla User a la lógica de **Spatie**. En esta fase no se implementa aun el sistema de roles. 

Los datos se reciben de una Request genérica a la espera de que lleguen derivados de la lógica de autenticacion que se está creando con github_id.

Los campos github_id y github_user_name en todas sus apariciones están comentados a la espera de que estén disponibles en la tabla User.

La documentación de Swagger también está pendiente en este punto,

Es **necesario revisar** estos puntos para **confirmar que son correctos:**
1) los datos que se reciben en  register() son los que se enviarán desde la lógica de autenticación de github 
2) los datos de la respuesta son los que espera el frontend. A falta de documentación en CreateRole he consultado CreateRoleNode.

