### PR TITLE
Implementación de Spatie Laravel Permission

### DIFF
--- a/app/Console/Commands/CreateSuperAdmin.php
+++ b/app/Console/Commands/CreateSuperAdmin.php
@@ -4,7 +4,7 @@ declare (strict_types= 1);
 
 namespace App\Console\Commands;
 
-use App\Models\Role;
+use App\Models\OldRole;
 use Illuminate\Console\Command;
 
 class CreateSuperAdmin extends Command
@@ -40,7 +40,7 @@ class CreateSuperAdmin extends Command
             return Command::FAILURE;
         }
 
-        Role::create([
+        OldRole::create([
             'github_id' => $superadmin_github_id,
             'role' => 'superadmin',
         ]);

--- a/app/Http/Controllers/OldRoleController.php
+++ b/app/Http/Controllers/OldRoleController.php
@@ -8,7 +8,7 @@ use App\Http\Requests\UpdateRoleRequest;
 use App\Services\CreateRoleService;
 use App\Services\UpdateRoleService;
 use Illuminate\Http\Request;
-use App\Models\Role;
+use App\Models\OldRole;
 use Illuminate\Http\JsonResponse;
 use App\Rules\GithubIdRule;
 use Illuminate\Support\Facades\Config;
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Config;
 /**
  * @deprecated 
  */
-class RoleController extends Controller
+class OldRoleController extends Controller
 {
     /**
      * @OA\Post(
@@ -162,7 +162,7 @@ class RoleController extends Controller
             'github_id' => 'required|integer'
         ]);
 
-        $role = Role::where('github_id', $validated['github_id'])->first();
+        $role = OldRole::where('github_id', $validated['github_id'])->first();
 
         if (!$role) {
             return response()->json([
@@ -235,7 +235,7 @@ class RoleController extends Controller
             'role' => ['required', 'string', 'in:superadmin,mentor,admin,student']
         ]);
 
-        $role = Role::where('github_id', $validated['github_id'])->first();
+        $role = OldRoleRole::where('github_id', $validated['github_id'])->first();
 
         if (!$role) {
             return response()->json([

--- a/app/Http/Controllers/OldRoleController.php
+++ b/app/Http/Controllers/OldRoleController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 use App\Http\Requests\CreateRoleRequest;
 use App\Http\Requests\UpdateRoleRequest;
-use App\Services\CreateRoleService;
-use App\Services\UpdateRoleService;
+use App\Services\OldCreateRoleService;
+use App\Services\OldUpdateRoleService;
 use Illuminate\Http\Request;
 use App\Models\OldRole;
 use Illuminate\Http\JsonResponse;
@@ -60,7 +60,7 @@ class OldRoleController extends Controller
      * )
      */
     
-    public function createRole(CreateRoleRequest $request, CreateRoleService $createRoleService): JsonResponse
+    public function createRole(CreateRoleRequest $request, OldCreateRoleService $createRoleService): JsonResponse
     {
         return $createRoleService($request->validated());
     }
@@ -108,7 +108,7 @@ class OldRoleController extends Controller
     */
     
 
-    public function updateRole(UpdateRoleRequest $request, UpdateRoleService $updateRoleService): JsonResponse
+    public function updateRole(UpdateRoleRequest $request, OldUpdateRoleService $updateRoleService): JsonResponse
     {
         return $updateRoleService($request->validated());
     }
@@ -235,7 +235,7 @@ class OldRoleController extends Controller
             'role' => ['required', 'string', 'in:superadmin,mentor,admin,student']
         ]);
 
-        $role = OldRoleRole::where('github_id', $validated['github_id'])->first();
+        $role = OldRole::where('github_id', $validated['github_id'])->first();
 
         if (!$role) {
             return response()->json([

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Passport\HasApiTokens;
+
+class UserController extends Controller
+{
+    public function updateRole(Request $request, User $user) 
+{ /* ... */ }
+
+    public function profile(Request $request) { /* ... */ }
+
+    public function index() { /* listar usuarios */ }
+
+    public function destroy(User $user) { /* eliminar usuario */ }
+
+}

--- a/app/Http/Requests/CreateRoleRequest.php
+++ b/app/Http/Requests/CreateRoleRequest.php
@@ -24,8 +24,8 @@ class CreateRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'authorized_github_id' => ['required', 'int', 'gt:0', 'exists:roles,github_id'],
-            'github_id' => ['required', 'int', 'gt:0', 'unique:roles,github_id'],   
+            'authorized_github_id' => ['required', 'int', 'gt:0', 'exists:old_roles,github_id'],
+            'github_id' => ['required', 'int', 'gt:0', 'unique:old_roles,github_id'],   
             'role' => ['required', 'string', 'in:superadmin,mentor,admin,student'],
         ];
     }   

--- a/app/Models/Bookmark.php
+++ b/app/Models/Bookmark.php
@@ -4,6 +4,7 @@ declare (strict_types= 1);
 
 namespace App\Models;
 
+use App\Models\User;
 use App\Observers\BookmarkObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
@@ -34,9 +35,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
         return $this->belongsTo(Resource::class);
     }
 
-    public function role()
+    public function user()
     {
-        return $this->belongsTo(Role::class, 'github_id', 'github_id');
+        return $this->belongsTo(User::class, 'github_id', 'github_id');
     }
 }
 

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -4,6 +4,7 @@ declare (strict_types= 1);
 
 namespace App\Models;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Observers\LikeObserver;
@@ -35,8 +36,8 @@ class Like extends Model
         return $this->belongsTo(Resource::class);
     }
 
-    public function role()
+    public function user()
     {
-        return $this->belongsTo(Role::class, 'github_id', 'github_id');
+        return $this->belongsTo(User::class, 'github_id', 'github_id');
     }
 }

--- a/app/Models/OldRole.php
+++ b/app/Models/OldRole.php
@@ -17,12 +17,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-03-17T19:23:41.000000Z")
 * )
 */
-class Role extends Model
+class OldRole extends Model
 {
     /** @use HasFactory<\Database\Factories\RoleFactory> */
     use HasFactory;
 
-    protected $table = 'roles';
+    protected $table = 'old_roles';
     protected $fillable = [
         'github_id',
         'role'

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -47,9 +47,9 @@ class Resource extends Model
         'tags' => 'array'
     ];
 
-    public function role()
+    public function user()
     {
-        return $this->belongsTo(Role::class);
+        return $this->belongsTo(User::class, 'github_id', 'github_id');
     }
 
     public function bookmarks()

--- a/app/Rules/GithubIdRule.php
+++ b/app/Rules/GithubIdRule.php
@@ -19,7 +19,7 @@ class GithubIdRule implements ValidationRule
     {
         $validator = Validator::make(
             [$attribute => $value],
-            [$attribute => ['required', 'integer', 'min:1', 'exists:roles,github_id']]
+            [$attribute => ['required', 'integer', 'min:1', 'exists:old_roles,github_id']]
         );
 
         if ($validator->fails()) {

--- a/app/Rules/OldRoleStudentRule.php
+++ b/app/Rules/OldRoleStudentRule.php
@@ -4,7 +4,7 @@ declare (strict_types= 1);
 
 namespace App\Rules;
 
-use App\Models\Role;
+use App\Models\OldRole;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
@@ -17,7 +17,7 @@ class RoleStudentRule implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $role = Role::where('github_id', $value)->first();
+        $role = OldRole::where('github_id', $value)->first();
         if (!$role || $role->role !== 'student') {
             $fail('The github_id must belong to a student role.');
         }

--- a/app/Rules/OldRoleStudentRule.php
+++ b/app/Rules/OldRoleStudentRule.php
@@ -8,7 +8,7 @@ use App\Models\OldRole;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
-class RoleStudentRule implements ValidationRule
+class OldRoleStudentRule implements ValidationRule
 {
     /**
      * Run the validation rule.

--- a/app/Rules/RoleStudentRule.php
+++ b/app/Rules/RoleStudentRule.php
@@ -8,7 +8,7 @@ use App\Models\OldRole;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
-class OldRoleStudentRule implements ValidationRule
+class RoleStudentRule implements ValidationRule
 {
     /**
      * Run the validation rule.

--- a/app/Services/CreateRoleNodeService.php
+++ b/app/Services/CreateRoleNodeService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Models\Role;
+
 use App\Models\RoleNode;
 use Illuminate\Http\JsonResponse;
 use App\Http\Requests\CreateRoleNodeRequest;

--- a/app/Services/OldCreateRoleService.php
+++ b/app/Services/OldCreateRoleService.php
@@ -5,14 +5,14 @@ declare (strict_types= 1);
 namespace App\Services;
 
 use App\Http\Requests\CreateRoleRequest;
-use App\Models\Role;
+use App\Models\OldRole;
 use Illuminate\Http\JsonResponse;
 
-class CreateRoleService
+class OldCreateRoleService
 {
     public function __invoke(array $validated)
     {
-        $authorizedRole = (Role::where('github_id', $validated['authorized_github_id'])->first())->role;
+        $authorizedRole = (OldRole::where('github_id', $validated['authorized_github_id'])->first())->role;
 
         $githubId = $validated['github_id'];
         $roleToCreate = $validated['role'];
@@ -39,7 +39,7 @@ class CreateRoleService
             return response()->json(['message' => 'No puedes crear un rol igual o superior al tuyo.'], 403);
         }
 
-        $role = Role::create([
+        $role = OldRole::create([
             'github_id' => $githubId,
             'role' => $roleToCreate,
         ]);

--- a/app/Services/OldUpdateRoleService.php
+++ b/app/Services/OldUpdateRoleService.php
@@ -4,14 +4,14 @@ declare (strict_types= 1);
 
 namespace App\Services;
 
-use App\Models\Role;
+use App\Models\OldRole;
 use Illuminate\Http\JsonResponse;
 
-class UpdateRoleService
+class OldUpdateRoleService
 {
     public function __invoke(array $validated)
     {
-        $authorizedRole = (Role::where('github_id', $validated['authorized_github_id'])->firstOrFail())->role;
+        $authorizedRole = (OldRole::where('github_id', $validated['authorized_github_id'])->firstOrFail())->role;
 
         $githubId = $validated['github_id'];
         $roleToUpdate = $validated['role'];
@@ -28,7 +28,7 @@ class UpdateRoleService
     protected function processRoleUpdate(string $authorizedRole, string $roleToUpdate, int $githubId): JsonResponse
     {
         $authorizedLevel = $this->getRoleLevel($authorizedRole);
-        $currentLevel = $this->getRoleLevel(Role::where('github_id', $githubId)->firstOrFail()->role);
+        $currentLevel = $this->getRoleLevel(OldRole::where('github_id', $githubId)->firstOrFail()->role);
         $updateLevel = $this->getRoleLevel($roleToUpdate);
 
         if ($authorizedLevel <= $currentLevel) {
@@ -43,7 +43,7 @@ class UpdateRoleService
             return response()->json(['message' => 'No puedes actualizar un rol a un orden igual o superior al tuyo.'], 403);
         }
 
-        $role = Role::where('github_id', $githubId)->update([
+        $role = OldRole::where('github_id', $githubId)->update([
             'role' => $roleToUpdate
         ]);
 

--- a/app/Services/UpdateRoleNodeService.php
+++ b/app/Services/UpdateRoleNodeService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Models\Role;
+
 use App\Models\RoleNode;
 use Illuminate\Http\JsonResponse;
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "darkaonline/l5-swagger": "^9.0",
         "laravel/framework": "^11.31",
         "laravel/socialite": "^5.8",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9",
+        "spatie/laravel-permission": "^6.21"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "593f3b1836aea770b5917b1517a53a3f",
+    "content-hash": "cb7a07720678c7df00bbf1763e42595c",
     "packages": [
         {
             "name": "brick/math",
@@ -3915,6 +3915,89 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.8.1"
             },
             "time": "2025-06-01T06:28:46+00:00"
+        },
+        {
+            "name": "spatie/laravel-permission",
+            "version": "6.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-permission.git",
+                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/container": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/database": "^8.12|^9.0|^10.0|^11.0|^12.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/passport": "^11.0|^12.0",
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
+                "phpunit/phpunit": "^9.4|^10.1|^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Permission\\PermissionServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "6.x-dev",
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Permission\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Permission handling for Laravel 8.0 and up",
+            "homepage": "https://github.com/spatie/laravel-permission",
+            "keywords": [
+                "acl",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-permission/issues",
+                "source": "https://github.com/spatie/laravel-permission/tree/6.21.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-23T16:08:05+00:00"
         },
         {
             "name": "swagger-api/swagger-ui",

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,202 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/factories/BookmarkFactory.php
+++ b/database/factories/BookmarkFactory.php
@@ -5,7 +5,7 @@ declare (strict_types= 1);
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\Role;
+use App\Models\User;
 use App\Models\Resource;
 use App\Models\Bookmark;
 
@@ -25,7 +25,7 @@ class BookmarkFactory extends Factory
     public function definition()
     {
 
-        $students = Role::where('role', 'student')->pluck('github_id');
+        $students = User::pluck('github_id');
         $resources = Resource::pluck('id');
         $combinations = $students->crossJoin($resources);
 

--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -5,7 +5,7 @@ declare (strict_types= 1);
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\Role;
+use App\Models\User;
 use App\Models\Resource;
 use App\Models\Like;
 
@@ -24,7 +24,7 @@ class LikeFactory extends Factory
 
     public function definition()
     {
-        $students = Role::where('role', 'student')->pluck('github_id');
+        $students = User::pluck('github_id');
         $resources = Resource::pluck('id');
         $combinations = $students->crossJoin($resources);
 

--- a/database/factories/OldRoleFactory.php
+++ b/database/factories/OldRoleFactory.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\Role;
+use App\Models\OldRole;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Role>
  */
-class RoleFactory extends Factory
+class OldRoleFactory extends Factory
 {
     /**
      * Define the model's default state.
@@ -20,7 +20,7 @@ class RoleFactory extends Factory
     {
         do {
             $githubId = $this->faker->numberBetween(1, 10000000);
-        } while (Role::where('github_id', $githubId)->exists());
+        } while (OldRole::where('github_id', $githubId)->exists());
         return [
             'github_id' => $githubId,
             'role' => $this->faker->randomElement(['admin', 'mentor', 'student']),

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -4,7 +4,8 @@ declare (strict_types= 1);
 
 namespace Database\Factories;
 
-use App\Models\Role;
+use App\Models\User;
+use App\Models\OldRole;
 use App\Models\Tag;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -19,11 +20,12 @@ class ResourceFactory extends Factory
      * @return array<string, mixed>
      */
     public function definition(): array
-    {
-        $role = Role::where('role', '=', 'student')
-        ->inRandomOrder()
-        ->first();
-
+    {   /*Antiguo sistema de gestion de permisos. Elminar cuando Spatie esté implementado
+        * 
+            $role = OldRole::where('role', '=', 'student')
+            ->inRandomOrder()
+            ->first();
+        */
         $validTags = Tag::all()->pluck('name')->toArray();
 
         $createdAtDate = $this->faker->dateTimeBetween('-2 years', 'now');
@@ -31,7 +33,7 @@ class ResourceFactory extends Factory
         $updatedAtDate = $this->faker->boolean(50)? $createdAtDate : $this->faker->dateTimeBetween($createdAtDate, 'now');
 
         return [
-            'github_id' => $role->github_id,
+            'github_id' => User::factory()->create()->github_id,
             'title' => $this->faker->sentence(4),
             'description' => $this->faker->sentence(6),
             'url' => $this->faker->url(),

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -20,12 +20,12 @@ class ResourceFactory extends Factory
      * @return array<string, mixed>
      */
     public function definition(): array
-    {   /*Antiguo sistema de gestion de permisos. Elminar cuando Spatie esté implementado
-        * 
-            $role = OldRole::where('role', '=', 'student')
+    {   
+        // ELIMINAR cuando Spatie se implemente totalmente
+        $role = OldRole::where('role', '=', 'student')
             ->inRandomOrder()
             ->first();
-        */
+        
         $validTags = Tag::all()->pluck('name')->toArray();
 
         $createdAtDate = $this->faker->dateTimeBetween('-2 years', 'now');

--- a/database/migrations/2025_07_27_095315_rename_table_roles.php
+++ b/database/migrations/2025_07_27_095315_rename_table_roles.php
@@ -1,0 +1,20 @@
+<?php
+
+declare (strict_types= 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::rename('roles', 'old_roles');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('old_roles', 'roles');
+    }
+};

--- a/database/migrations/2025_07_27_100016_change_bookmarks_foreign_key_to_users.php
+++ b/database/migrations/2025_07_27_100016_change_bookmarks_foreign_key_to_users.php
@@ -1,0 +1,30 @@
+<?php
+
+declare (strict_types= 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bookmarks', function (Blueprint $table) {
+            $table->dropForeign(['github_id']);
+
+            $table->foreign('github_id')
+                ->references('github_id')
+                ->on('users')
+                ->onUpdate('cascade')
+                ->onDelete('restrict');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2025_07_27_100030_change_likes_foreign_key_to_users.php
+++ b/database/migrations/2025_07_27_100030_change_likes_foreign_key_to_users.php
@@ -1,0 +1,33 @@
+<?php
+
+declare (strict_types= 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('likes', function (Blueprint $table) {
+            $table->dropForeign(['github_id']);
+
+            $table->foreign('github_id')
+                ->references('github_id')
+                ->on('users')
+                ->onUpdate('cascade')
+                ->onDelete('restrict');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2025_07_27_100053_change_resources_foreign_key_to_users.php
+++ b/database/migrations/2025_07_27_100053_change_resources_foreign_key_to_users.php
@@ -1,0 +1,30 @@
+<?php
+
+declare (strict_types= 1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            
+            $table->dropForeign(['github_id']);
+
+            $table->foreign('github_id')
+                ->references('github_id')
+                ->on('users')
+                ->onUpdate('cascade')
+                ->onDelete('restrict');
+         });
+    }
+  
+    public function down(): void
+    {
+        Schema::dropIfExists('resources');
+    }
+    
+};

--- a/database/migrations/2025_07_27_100248_create_permission_tables.php
+++ b/database/migrations/2025_07_27_100248_create_permission_tables.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(empty($tableNames), new Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+        throw_if($teams && empty($columnNames['team_foreign_key'] ?? null), new Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+};

--- a/database/seeders/BookmarkSeeder.php
+++ b/database/seeders/BookmarkSeeder.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\Bookmark;
 use App\Models\Resource;
-use App\Models\Role;
+use App\Models\User;
 
 class BookmarkSeeder extends Seeder
 {
@@ -19,8 +19,8 @@ class BookmarkSeeder extends Seeder
     public function run()
     {
         // First 3 manually created bookmarks using Role created by Seeder
-        $knownStudentId = 6729608;
-        $knownStudent = Role::where('github_id', $knownStudentId)->firstOrFail();
+        $knownStudentId = 999999999;
+        $knownStudent = User::where('github_id', $knownStudentId)->firstOrFail();
         $resources = Resource::inRandomOrder()->take(3)->get();
         
         foreach ($resources as $resource) {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,7 +20,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             UserSeeder::class,
-            RoleSeeder::class,        RoleNodeSeeder::class,      // for node_id transition
+            OldRoleSeeder::class,        RoleNodeSeeder::class,      // for node_id transition
             TagSeeder::class,         TagNodeSeeder::class,       //for node_id transition
             ResourceSeeder::class,    ResourceNodeSeeder::class,  // for node_id transition
             BookmarkSeeder::class,    BookmarkNodeSeeder::class,  // for node_id transition

--- a/database/seeders/LikeSeeder.php
+++ b/database/seeders/LikeSeeder.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\Like;
 use App\Models\Resource;
-use App\Models\Role;
+use App\Models\User;
 
 class LikeSeeder extends Seeder
 {
@@ -19,8 +19,8 @@ class LikeSeeder extends Seeder
     public function run(): void
     {
         // First 3 manually created likes using Role created by Seeder
-        $knownStudentId = 6729608;
-        $knownStudent = Role::where('github_id', $knownStudentId)->firstOrFail();
+        $knownStudentId = 999999999;
+        $knownStudent = User::where('github_id', $knownStudentId)->firstOrFail();
         $resources = Resource::inRandomOrder()->take(3)->get();
         
         foreach ($resources as $resource) {

--- a/database/seeders/OldRoleSeeder.php
+++ b/database/seeders/OldRoleSeeder.php
@@ -3,22 +3,22 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use App\Models\Role;
+use App\Models\OldRole;
 
-class RoleSeeder extends Seeder
+class OldRoleSeeder extends Seeder
 {
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        Role::create(['github_id' => 1, 'role' => 'superadmin']);
+        OldRole::create(['github_id' => 1, 'role' => 'superadmin']);
 
-        Role::create([
+        OldRole::create([
             'github_id' => 6729608,
             'role' => 'student',
         ]);
 
-        Role::factory()->count(20)->create();
+        OldRole::factory()->count(20)->create();
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -9,9 +9,6 @@ use App\Models\User;
 
 class UserSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
        User::factory()->create([

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\TagController;
 use App\Http\Controllers\LikeController;
-use App\Http\Controllers\RoleController;
+use App\Http\Controllers\OldRoleController;
 use App\Http\Controllers\BookmarkController;
 use App\Http\Controllers\ResourceController;
 use App\Http\Controllers\GitHubAuthController;
@@ -21,10 +21,10 @@ Route::get('/auth/github/callback', [GitHubAuthController::class, 'callback']);
 
 
 // (Old)Roles Endpoints: in the current permission logic, Roles table refers to Users
-Route::post('/login', [RoleController::class, 'getRoleByGithubId'])->name('login');
-Route::post('/roles', [RoleController::class, 'createRole'])->name('roles.create');
-Route::put('/roles', [RoleController::class, 'updateRole'])->name('roles.update');
-Route::put('/feature-flags/role-self-assignment', [RoleController::class, 'roleSelfAssignment'])->name('feature-flags.role-self-assignment');
+Route::post('/login', [OldRoleController::class, 'getRoleByGithubId'])->name('login');
+Route::post('/roles', [OldRoleController::class, 'createRole'])->name('roles.create');
+Route::put('/roles', [OldRoleController::class, 'updateRole'])->name('roles.update');
+Route::put('/feature-flags/role-self-assignment', [OldRoleController::class, 'roleSelfAssignment'])->name('feature-flags.role-self-assignment');
 
 
 //TECHNICAL TESTS ENDPOINTS

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,7 +38,7 @@ Route::get('/resources', [ResourceController::class, 'index'])->name('resources'
 Route::put('/resources/{resource}', [ResourceEditController::class, 'update'])->name('resources.update');
 //Resources Endpoints v2
 Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name('resources.store.v2');
-Route::get('v2/resources', [ResourceController::class, 'showResource'])->name('showResource');
+Route::get('/V2/resources', [ResourceController::class, 'showResource'])->name('showResource');
 
 
 //Likes Endpoints

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,33 +13,59 @@ use App\Http\Controllers\Api\RoleNodeController;
 use App\Http\Controllers\ResourceEditController;
 use App\Http\Controllers\Api\BookmarkNodeController;
 
+
+
+//GitHub Auth Systen Endpoints
 Route::get('/auth/github/redirect', [GitHubAuthController::class, 'redirect']);
 Route::get('/auth/github/callback', [GitHubAuthController::class, 'callback']);
-Route::post('/resources', [ResourceController::class, 'store'])->name('resources.store');
-Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name('resources.store.v2');
-Route::get('/resources', [ResourceController::class, 'index'])->name('resources');
-Route::get('v2/resources', [ResourceController::class, 'showResource'])->name('showResource');
+
+
+// (Old)Roles Endpoints: in the current permission logic, Roles table refers to Users
 Route::post('/login', [RoleController::class, 'getRoleByGithubId'])->name('login');
-Route::put('/resources/{resource}', [ResourceEditController::class, 'update'])->name('resources.update');
-Route::get('/bookmarks/{github_id}', [BookmarkController::class,'getStudentBookmarks'])->name('bookmarks');
-Route::post('/bookmarks', [BookmarkController::class,'createStudentBookmark'])->name('bookmark.create');
-Route::delete('/bookmarks', [BookmarkController::class,'deleteStudentBookmark'])->name('bookmark.delete');
 Route::post('/roles', [RoleController::class, 'createRole'])->name('roles.create');
 Route::put('/roles', [RoleController::class, 'updateRole'])->name('roles.update');
-Route::get('/likes/{github_id}', [LikeController::class,'getStudentLikes'])->name('likes');
-Route::post('/likes', [LikeController::class,'createStudentLike'])->name('like.create');
-Route::delete('/likes', [LikeController::class,'deleteStudentLike'])->name('like.delete');
-Route::get('/tags', [TagController::class, 'index'])->name('tags');
-Route::get('/tags/frequency', [TagController::class, 'getTagsFrequency'])->name('tags.frequency');
-Route::get('/tags/category-frequency', [TagController::class, 'getCategoryTagsFrequency'])->name('category.tags.frequency');
-Route::get('/tags/by-category', [TagController::class, 'getCategoryTagsId'])->name('category.tags.id');
-
-// FEATURE FLAGS ENDPOINTS
 Route::put('/feature-flags/role-self-assignment', [RoleController::class, 'roleSelfAssignment'])->name('feature-flags.role-self-assignment');
 
 
+//TECHNICAL TESTS ENDPOINTS
+Route::get('/technical-tests', [TechnicalTestController::class, 'index'])->name('technical-tests.index');
+Route::post('/technical-tests', [TechnicalTestController::class, 'store']);
 
-//new github_id to node_id transition ENDPOINTS
+
+//Resources Endpoints
+Route::post('/resources', [ResourceController::class, 'store'])->name('resources.store');
+Route::get('/resources', [ResourceController::class, 'index'])->name('resources');
+Route::put('/resources/{resource}', [ResourceEditController::class, 'update'])->name('resources.update');
+//Resources Endpoints v2
+Route::post('/v2/resources', [ResourceController::class, 'storeResource'])->name('resources.store.v2');
+Route::get('v2/resources', [ResourceController::class, 'showResource'])->name('showResource');
+
+
+//Likes Endpoints
+Route::get('/likes/{github_id}', [LikeController::class,'getStudentLikes'])->name('likes');
+Route::post('/likes', [LikeController::class,'createStudentLike'])->name('like.create');
+Route::delete('/likes', [LikeController::class,'deleteStudentLike'])->name('like.delete');
+
+
+//Bookmarks Endpoints
+Route::get('/bookmarks/{github_id}', [BookmarkController::class,'getStudentBookmarks'])->name('bookmarks');
+Route::post('/bookmarks', [BookmarkController::class,'createStudentBookmark'])->name('bookmark.create');
+Route::delete('/bookmarks', [BookmarkController::class,'deleteStudentBookmark'])->name('bookmark.delete');
+
+
+//Tags Endpoints
+Route::get('/tags/frequency', [TagController::class, 'getTagsFrequency'])->name('tags.frequency');
+Route::get('/tags/category-frequency', [TagController::class, 'getCategoryTagsFrequency'])->name('category.tags.frequency');
+Route::get('/tags/by-category', [TagController::class, 'getCategoryTagsId'])->name('category.tags.id');
+Route::get('/tags', [TagController::class, 'index'])->name('tags');
+
+
+
+/*
+* New github_id to node_id transition ENDPOINTS
+*/ 
+
+//Roles Node Endpoints
 Route::post('/roles-node', [RoleNodeController::class, 'createRoleNode'])->name('roles-node.create');
 Route::put('/roles-node',  [RoleNodeController::class, 'updateRoleNode'])->name('roles-node.update');
 Route::post('/login-node', [RoleNodeController::class, 'getRoleByNodeId'])->name('login-node');
@@ -51,7 +77,6 @@ Route::put('/feature-flags/role-self-assignment-node', [RoleNodeController::clas
 Route::post('/bookmarks-node',   [BookmarkNodeController::class, 'createStudentBookmarkNode'])->name('bookmark-node.create');
 Route::delete('/bookmarks-node', [BookmarkNodeController::class, 'deleteStudentBookmarkNode'])->name('bookmark-node.delete');
 Route::get('/bookmarks-node/{node_id}', [BookmarkNodeController::class, 'getStudentBookmarksNode'])->name('bookmarks-node');
-
 
 //TAGSNODE ENDPOINTS
 Route::get('/tags-node', [TagNodeController::class, 'index'])->name('tags-node');
@@ -66,6 +91,3 @@ Route::get('/tags-node/by-category', [TagNodeController::class, 'getCategoryTags
 //RESOURCESNODE ENDPOINTS
 
 
-//TECHNICAL TESTS ENDPOINTS
-Route::get('/technical-tests', [TechnicalTestController::class, 'index'])->name('technical-tests.index');
-Route::post('/technical-tests', [TechnicalTestController::class, 'store']);

--- a/tests/Feature/BookmarkControllerTest.php
+++ b/tests/Feature/BookmarkControllerTest.php
@@ -5,13 +5,15 @@ declare (strict_types= 1);
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use App\Models\Role;
+use App\Models\User;
+use App\Models\OldRole;
 use App\Models\Resource;
 use App\Models\Bookmark;
 
+
 class BookmarkControllerTest extends TestCase
 {
-    protected $student;
+    protected $user;
     protected $resources;
     protected $bookmarks;
 
@@ -19,8 +21,13 @@ class BookmarkControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->student = Role::factory()->create([
+        $this->user = User::factory()->create([
             'github_id' => 9871315,
+        ]);
+
+        // ELIMINAR cuando Spatie se implemente totalmente 
+        OldRole::factory()->create([
+            'github_id' => $this->user->github_id,
             'role' => 'student'
         ]);
 
@@ -28,22 +35,22 @@ class BookmarkControllerTest extends TestCase
 
         $this->bookmarks = [
             Bookmark::create([
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->resources[0]->id]),
             Bookmark::create([
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->resources[1]->id])
         ];
     }
 
     public function testGetStudentBookmarks(): void
     {
-        $response = $this->get('api/bookmarks/' . $this->student->github_id);
+        $response = $this->get('api/bookmarks/' . $this->user->github_id);
         $response->assertStatus(200)
             ->assertJsonCount(2)
             ->assertJson([
-                ['github_id' => $this->student->github_id, 'resource_id' => $this->resources[0]->id],
-                ['github_id' => $this->student->github_id, 'resource_id' => $this->resources[1]->id]
+                ['github_id' => $this->user->github_id, 'resource_id' => $this->resources[0]->id],
+                ['github_id' => $this->user->github_id, 'resource_id' => $this->resources[1]->id]
             ]);
     }
 
@@ -58,7 +65,7 @@ class BookmarkControllerTest extends TestCase
         $initial_count = $this->bookmarks[1]->resource->bookmark_count;
 
         $response = $this->delete('api/bookmarks', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->bookmarks[1]->resource_id
         ]);
                 
@@ -67,7 +74,7 @@ class BookmarkControllerTest extends TestCase
 
 
         $this->assertDatabaseMissing('bookmarks', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->bookmarks[1]->resource_id
         ]);
 
@@ -81,18 +88,18 @@ class BookmarkControllerTest extends TestCase
         $initial_count = $test_increment_resource->bookmark_count;
 
         $response = $this->post('api/bookmarks', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->resources[2]->id
         ]);
 
         $response->assertStatus(201)
             ->assertJson([
-                'github_id' => $this->student->github_id,
+                'github_id' => $this->user->github_id,
                 'resource_id' => $this->resources[2]->id,
             ]);
 
         $this->assertDatabaseHas('bookmarks', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->resources[2]->id
         ]);
 
@@ -110,7 +117,7 @@ class BookmarkControllerTest extends TestCase
 
     public function testCreateBookmarkForNonexistentResourceFails(): void {
         $response = $this->post('api/bookmarks', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => 447012
         ]);
         $response->assertStatus(422);

--- a/tests/Feature/CreateResourceTest.php
+++ b/tests/Feature/CreateResourceTest.php
@@ -6,21 +6,30 @@ namespace Tests\Feature;
 
 use App\Models\Tag;
 use Tests\TestCase;
-use App\Models\Role;
+use App\Models\User;
+use App\Models\OldRole;
 use App\Models\Resource;
 use Illuminate\Foundation\Testing\WithFaker;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class CreateResourceTest extends TestCase
 {
+    use RefreshDatabase;
     use WithFaker;
-
+    
     private function GetResourceData(): array
     {
-        $role = Role::factory()->create(['role' => 'student']);
+        $user = User::factory()->create();
+
+        // ELIMINAR cuando Spatie se implemente totalmente 
+        OldRole::factory()->create([ 
+            'github_id' => $user->github_id,
+            'role' => 'student'
+        ]);
 
         return Resource::factory()->raw([
-            'github_id' => $role->github_id,
+            'github_id' => $user->github_id,
             //'tags' => null
         ]);
        
@@ -28,11 +37,18 @@ class CreateResourceTest extends TestCase
 
     private function GetResourceDataTagsId(): array
     {
-        $role = Role::factory()->create(['role' => 'student']);
+        $user = User::factory()->create();
+
+        // ELIMINAR cuando Spatie se implemente totalmente 
+        OldRole::factory()->create([
+            'github_id' => $user->github_id,
+            'role' => 'student'
+        ]);
+
         $tagIds = Tag::inRandomOrder()->take(3)->pluck('id')->toArray();
 
         return Resource::factory()->raw([
-            'github_id' => $role->github_id,
+            'github_id' => $user->github_id,
             'tags' => $tagIds // Assuming these IDs exist in the tags table
         ]);
     }

--- a/tests/Feature/LikeControllerTest.php
+++ b/tests/Feature/LikeControllerTest.php
@@ -5,13 +5,16 @@ declare (strict_types= 1);
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use App\Models\Role;
+use App\Models\User;
 use App\Models\Resource;
 use App\Models\Like;
+use App\Models\OldRole; // ← Eliminar cuando Spatie esté implementado
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class LikeControllerTest extends TestCase
 {
-    protected $student;
+    use RefreshDatabase;
+    protected $user;
     protected $resources;
     protected $likes;
 
@@ -19,8 +22,13 @@ class LikeControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->student = Role::factory()->create([
+        $this->user = User::factory()->create([
             'github_id' => 9871315,
+        ]);
+    
+        // ELIMINAR: cuando Spatie esté implementado
+        OldRole::factory()->create([
+            'github_id' => $this->user->github_id,
             'role' => 'student'
         ]);
 
@@ -28,22 +36,29 @@ class LikeControllerTest extends TestCase
 
         $this->likes = [
             Like::create([
-            'github_id' => $this->student->github_id,
-            'resource_id' => $this->resources[0]->id]),
+                'github_id' => $this->user->github_id,
+                'resource_id' => $this->resources[0]->id]),
             Like::create([
-            'github_id' => $this->student->github_id,
-            'resource_id' => $this->resources[1]->id])
+                'github_id' => $this->user->github_id,
+                'resource_id' => $this->resources[1]->id])
         ];
     }
 
     public function testGetStudentLikes(): void
     {
-        $response = $this->get('api/likes/' . $this->student->github_id);
+        $response = $this->get('api/likes/' . $this->user->github_id);
+
+        // ← AÑADIR ESTAS LÍNEAS PARA DEBUG
+        if ($response->status() !== 200) {
+            dump('Response status: ' . $response->status());
+            dump('Response body: ' . $response->getContent());
+        }
+    
         $response->assertStatus(200)
             ->assertJsonCount(2)
             ->assertJson([
-                ['github_id' => $this->student->github_id, 'resource_id' => $this->resources[0]->id],
-                ['github_id' => $this->student->github_id, 'resource_id' => $this->resources[1]->id]
+                ['github_id' => $this->user->github_id, 'resource_id' => $this->resources[0]->id],
+                ['github_id' => $this->user->github_id, 'resource_id' => $this->resources[1]->id]
             ]);
     }
 
@@ -56,7 +71,7 @@ class LikeControllerTest extends TestCase
     public function testDestroyLike(): void
     {
         $response = $this->delete('api/likes', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->likes[1]->resource_id
         ]);
                 
@@ -65,7 +80,7 @@ class LikeControllerTest extends TestCase
 
 
         $this->assertDatabaseMissing('likes', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->likes[1]->resource_id
         ]);
     }
@@ -73,18 +88,18 @@ class LikeControllerTest extends TestCase
     public function testCreateLike(): void
     {
         $response = $this->post('api/likes', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->resources[2]->id
         ]);
 
         $response->assertStatus(201)
             ->assertJson([
-                'github_id' => $this->student->github_id,
+                'github_id' => $this->user->github_id,
                 'resource_id' => $this->resources[2]->id,
             ]);
 
         $this->assertDatabaseHas('likes', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => $this->resources[2]->id
         ]);
     }
@@ -99,7 +114,7 @@ class LikeControllerTest extends TestCase
 
     public function testCreateLikeForNonexistentResourceFails(): void {
         $response = $this->post('api/likes', [
-            'github_id' => $this->student->github_id,
+            'github_id' => $this->user->github_id,
             'resource_id' => 447012
         ]);
         $response->assertStatus(422);

--- a/tests/Feature/OldCreateRoleTest.php
+++ b/tests/Feature/OldCreateRoleTest.php
@@ -4,19 +4,19 @@ declare (strict_types= 1);
 
 namespace Tests\Feature;
 
-use App\Models\Role;
+use App\Models\OldRole;
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class CreateRoleTest extends TestCase
+class OldCreateRoleTest extends TestCase
 {
-    private function createRole(string $role): Role
+    private function createRole(string $role): OldRole
     {
-        return Role::create([
+        return OldRole::create([
             'github_id' => random_int(100000, 999999),
             'role' => $role,
         ]);
-    }
+    }x
 
     private function requestCreateRole(int $github_id, string $role)
     {
@@ -112,7 +112,7 @@ class CreateRoleTest extends TestCase
 
     private function GetRoleData(): array
     {
-        return Role::factory()->raw(); 
+        return OldRole::factory()->raw(); 
     }    
 
     #[DataProvider('roleValidationProvider')]

--- a/tests/Feature/OldCreateRoleTest.php
+++ b/tests/Feature/OldCreateRoleTest.php
@@ -12,11 +12,12 @@ class OldCreateRoleTest extends TestCase
 {
     private function createRole(string $role): OldRole
     {
+        
         return OldRole::create([
             'github_id' => random_int(100000, 999999),
             'role' => $role,
         ]);
-    }x
+    }
 
     private function requestCreateRole(int $github_id, string $role)
     {
@@ -33,7 +34,7 @@ class OldCreateRoleTest extends TestCase
         
         $this->requestCreateRole($superadmin->github_id, 'admin')
         	->assertStatus(201);
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id'=> 123456,
             'role' => 'admin'
         ]);
@@ -45,7 +46,7 @@ class OldCreateRoleTest extends TestCase
         
         $this->requestCreateRole($admin->github_id, 'mentor')
         	->assertStatus(201);
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id'=> 123456,
             'role' => 'mentor'
         ]);
@@ -58,7 +59,7 @@ class OldCreateRoleTest extends TestCase
         $this->requestCreateRole($mentor->github_id, 'student')
         	->assertStatus(201);
 
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id'=> 123456,
             'role' => 'student'
         ]);
@@ -70,7 +71,7 @@ class OldCreateRoleTest extends TestCase
         
         $this->requestCreateRole($student->github_id, 'mentor')
         	->assertStatus(403);
-        $this->assertDatabaseMissing('roles', [
+        $this->assertDatabaseMissing('old_roles', [
             'github_id'=> 123456,
             'role' => 'mentor'
         ]);
@@ -82,7 +83,7 @@ class OldCreateRoleTest extends TestCase
         
         $this->requestCreateRole($mentor->github_id, 'admin')
         	->assertStatus(403);
-        $this->assertDatabaseMissing('roles', [
+        $this->assertDatabaseMissing('old_roles', [
             'github_id'=> 123456,
             'role' => 'admin'
         ]);
@@ -94,7 +95,7 @@ class OldCreateRoleTest extends TestCase
         
         $this->requestCreateRole($admin->github_id, 'superadmin')
         	->assertStatus(403);
-        $this->assertDatabaseMissing('roles', [
+        $this->assertDatabaseMissing('old_roles', [
             'github_id'=> 123456,
             'role' => 'superadmin'
         ]);

--- a/tests/Feature/OldRoleControllerTest.php
+++ b/tests/Feature/OldRoleControllerTest.php
@@ -4,16 +4,16 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
-use App\Models\Role;
+use App\Models\OldRole;
 
-class RoleControllerTest extends TestCase
+class OldRoleControllerTest extends TestCase
 {
     protected $student;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->student = Role::factory()->create([
+        $this->student = OldRole::factory()->create([
             'github_id' => 123456,
             'role' => 'student'
         ]);

--- a/tests/Feature/OldRoleSelfAssignmentTest.php
+++ b/tests/Feature/OldRoleSelfAssignmentTest.php
@@ -31,7 +31,7 @@ class OldRoleSelfAssignmentTest extends TestCase
 
         $response->assertStatus(200);
 
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id' => $this->student->github_id,
             'role' => 'mentor'
         ]);
@@ -46,12 +46,12 @@ class OldRoleSelfAssignmentTest extends TestCase
 
         $response->assertStatus(422);
 
-        $this->assertDatabaseMissing('roles', [
+        $this->assertDatabaseMissing('old_roles', [
             'github_id' => $this->student->github_id,
             'role' => 'nonexistent'
         ]);
 
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id' => $this->student->github_id,
             'role' => 'student'
         ]);

--- a/tests/Feature/OldRoleSelfAssignmentTest.php
+++ b/tests/Feature/OldRoleSelfAssignmentTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature;
 use Tests\TestCase;
 use App\Models\OldRole;
 
-class RoleSelfAssignmentTest extends TestCase
+class OldRoleSelfAssignmentTest extends TestCase
 {
     protected $student;
 

--- a/tests/Feature/OldRoleSelfAssignmentTest.php
+++ b/tests/Feature/OldRoleSelfAssignmentTest.php
@@ -5,7 +5,7 @@ declare (strict_types= 1);
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use App\Models\Role;
+use App\Models\OldRole;
 
 class RoleSelfAssignmentTest extends TestCase
 {
@@ -16,7 +16,7 @@ class RoleSelfAssignmentTest extends TestCase
         parent::setUp();
         config(['feature_flags.allow_role_self_assignment' => true]);
 
-        $this->student = Role::factory()->create([
+        $this->student = OldRole::factory()->create([
             'github_id' => random_int(1001, 9999999),
             'role' => 'student'
         ]);

--- a/tests/Feature/TagControllerTest.php
+++ b/tests/Feature/TagControllerTest.php
@@ -4,12 +4,15 @@ declare (strict_types= 1);
 namespace Tests\Feature;
 
 use App\Models\Resource;
-use App\Models\Role;
+use App\Models\User;
+use App\Models\OldRole;
 use App\Models\Tag;
 use Tests\TestCase;
 
 class TagControllerTest extends TestCase
 {
+    protected $user;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -26,8 +29,13 @@ class TagControllerTest extends TestCase
             ]);
         }
 
-        Role::factory()->create([
+        $this->user = User::factory()->create([
             'github_id' => 9871315,
+        ]);
+
+        // ELIMINAR cuando Spatie se implemente totalmente 
+        OldRole::factory()->create([
+            'github_id' => $this->user->github_id,
             'role' => 'student'
         ]);
 

--- a/tests/Feature/TechnicalTestIndexTest.php
+++ b/tests/Feature/TechnicalTestIndexTest.php
@@ -22,7 +22,7 @@ class TechnicalTestIndexTest extends TestCase
         BookmarkNode::truncate();
     }
 
-    public function test_can_get_technical_test_list_with_correct_structure()
+    public function testCanGetTechnicalTestListWithCorrectStructure()
     {
         TechnicalTest::factory(3)->create();
 
@@ -57,7 +57,7 @@ class TechnicalTestIndexTest extends TestCase
             ]);
     }
 
-    public function test_index_returns_correct_values(): void
+    public function testIndexReturnsCorrectValues(): void
     {
         TechnicalTest::factory()->create([
             'title' => 'Test PHP',
@@ -86,7 +86,7 @@ class TechnicalTestIndexTest extends TestCase
             ]);
     }
 
-    public function test_can_filter_by_language(): void
+    public function testCanFilterByLanguage(): void
     {
         TechnicalTest::factory()->create([
                 'title' => 'Test PHP',
@@ -110,7 +110,7 @@ class TechnicalTestIndexTest extends TestCase
             ]);  
     }
 
-    public function test_can_filter_by_multiple_parameters(): void
+    public function testCanFilterByMultipleParameters(): void
     {
         TechnicalTest::factory()->create([
             'language' => LanguageEnum::PHP->value,
@@ -129,7 +129,7 @@ class TechnicalTestIndexTest extends TestCase
             ->assertJsonFragment(['title' => 'PHP Advanced Test']);
     }
 
-    public function test_returns_empty_when_no_matches(): void
+    public function testReturnsEmptyWhenNoMatches(): void
     {
         TechnicalTest::factory()->create(['language' => LanguageEnum::PHP->value]);
 
@@ -143,7 +143,7 @@ class TechnicalTestIndexTest extends TestCase
         ]);
     }
 
-    public function test_returns_all_when_no_filters(): void
+    public function testReturnsAllWhenNoFilters(): void
     {
         TechnicalTest::factory(5)->create();
 
@@ -154,7 +154,7 @@ class TechnicalTestIndexTest extends TestCase
     }
     
     // No happy path tests
-    public function test_rejects_invalid_language(): void
+    public function testRejectsInvalidLanguage(): void
     {
         $invalidLanguage = 'InvalidLanguage';
         $this->assertFalse(in_array($invalidLanguage, array_column(LanguageEnum::cases(), 'value')));
@@ -169,7 +169,7 @@ class TechnicalTestIndexTest extends TestCase
     }
 
     
-    public function test_rejects_extremely_long_search_string(): void
+    public function testRejectsExtremelyLongSearchString(): void
     {
         $longString = str_repeat('a', 1000);
         
@@ -178,7 +178,7 @@ class TechnicalTestIndexTest extends TestCase
         $response->assertStatus(422);
     }
 
-    public function test_handles_special_characters_in_search(): void
+    public function testHandlesSpecialCharactersInSearch(): void
     {
         TechnicalTest::factory()->create(['title' => 'Test with special chars: @#$%']);
         

--- a/tests/Feature/UpdateResourceTest.php
+++ b/tests/Feature/UpdateResourceTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Models\Resource;
-use App\Models\Role;
+use App\Models\User;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UpdateResourceTest extends TestCase
 {
+    
+    use RefreshDatabase;
     use WithFaker;
 
     //creamos diferentes resources
@@ -29,14 +32,14 @@ class UpdateResourceTest extends TestCase
     public function testItCanUpdateAResource()
     {
 
-        $role = Role::factory()->create(['github_id' => 12345]);
+        $user = User::factory()->create(['github_id' => 12345]);
 
         
-        $resource = $this->createResource(['github_id' => $role->github_id]);
+        $resource = $this->createResource(['github_id' => $user->github_id]);
 
         // Datos para actualizar
         $data = [
-            'github_id' => $role->github_id, 
+            'github_id' => $user->github_id, 
             'title' => 'Updated title',
             'description' => 'Updated description',
             'url' => 'https://updated-url.com',

--- a/tests/Feature/UpdateRoleTest.php
+++ b/tests/Feature/UpdateRoleTest.php
@@ -5,10 +5,13 @@ declare (strict_types= 1);
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use App\Models\Role;
+use App\Models\OldRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UpdateRoleTest extends TestCase
 {
+    use RefreshDatabase;
+    
     protected $student;
     protected $mentor;
     protected $admin;
@@ -17,19 +20,19 @@ class UpdateRoleTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->student = Role::factory()->create([
+        $this->student = OldRole::factory()->create([
             'github_id' => 123456,
             'role' => 'student'
         ]);
-        $this->mentor = Role::factory()->create([
+        $this->mentor = OldRole::factory()->create([
             'github_id' => 234567,
             'role' => 'mentor'
         ]);
-        $this->admin = Role::factory()->create([
+        $this->admin = OldRole::factory()->create([
             'github_id' => 345678,
             'role' => 'admin'
         ]);
-        $this->superadmin = Role::factory()->create([
+        $this->superadmin = OldRole::factory()->create([
             'github_id' => 456789,
             'role' => 'superadmin'
         ]);
@@ -43,7 +46,7 @@ class UpdateRoleTest extends TestCase
             'role' => 'mentor'
         ])->assertStatus(200);
 
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id' => $this->student->github_id,
             'role' => 'mentor'
         ]);
@@ -57,7 +60,7 @@ class UpdateRoleTest extends TestCase
             'role' => 'student'
         ])->assertStatus(403);
 
-        $this->assertDatabaseHas('roles', [
+        $this->assertDatabaseHas('old_roles', [
             'github_id' => $this->admin->github_id,
             'role' => 'admin'
         ]);

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {   
+        parent::setUp();  
+        User::truncate();
+    }
+
+    protected function validUserData($overrides = [])
+    {
+        return array_merge([
+            'name' => 'Testing User',
+            'github_id' => 111111111,
+            'github_user_name' => 'testing github name',
+            'email' => 'testing@example.com',
+        //    'password' => 'password123',
+        //    'password_confirmation' => 'password123',
+        ], $overrides);
+    }
+/*
+    public function testRegisterCreatesUserWithCorrectData()
+    {
+        $data = $this->validUserData();
+
+        $response = $this->postJson('/api/register', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment([
+                'message' => 'User created successfully',
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'name' => $data['name'],
+            'github_id' => $data['github_id'],
+            'github_user_name' => $data['github_user_name'],
+            'email' => $data['email'],
+        ]);
+
+        $user = User::where('email', $data['email'])->first();
+        $this->assertTrue(Hash::check($data['password'], $user->password));
+    }
+
+    public function test_register_requires_all_fields()
+    {
+        $response = $this->postJson('/api/register', []);
+
+     // dump($response->getStatusCode());
+     // dump($response->json());    
+
+        $response->assertStatus(422);
+        $data = $response->json();
+
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayHasKey('email', $data);
+       // $this->assertArrayHasKey('password', $data);
+        $this->assertArrayHasKey('github_id', $data);
+        $this->assertArrayHasKey('github_user_name', $data);
+        
+        $this->assertEquals(['The name field is required.'], $data['name']);
+        $this->assertEquals(['The email field is required.'], $data['email']);
+      //  $this->assertEquals(['The password field is required.'], $data['password']);
+        $this->assertEquals(['The github_id field is required.'], $data['github_id']);
+        $this->assertEquals(['The github_user_name field is required.'], $data['github_user_name']);       
+    }
+
+    public function test_register_fails_with_duplicate_email()
+    {
+        User::factory()->create(['email' => 'testing@example.com']);
+        $data = $this->validUserData();
+
+        $response = $this->postJson('/api/register', $data);
+                
+        $response->assertStatus(422);
+        $data = $response->json();
+        
+        $this->assertArrayHasKey('email', $data);
+        $this->assertEquals(['The email has already been taken.'], $data['email']);
+
+    }
+
+    public function test_register_fails_with_password_confirmation_mismatch()
+    {
+        $data = $this->validUserData(['password_confirmation' => 'wrongpassword']);
+        $response = $this->postJson('/api/register', $data);
+
+        $response->assertStatus(422);
+        $data = $response->json();
+        
+        $this->assertArrayHasKey('password', $data);
+        $this->assertEquals(['The password field confirmation does not match.'], $data['password']);            
+    }
+*/
+}

--- a/tests/Feature/UserModelTest.php
+++ b/tests/Feature/UserModelTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\Models\User;
 use Tests\TestCase;


### PR DESCRIPTION
Esta PR prepara la aplicación para la transición del sistema de roles personalizado hacia Spatie Laravel Permission, adecua los nombres y el uso de las tablas User y Roles y deja Spatie instalado para que sea posible implementarlo.

### Principales Cambios
1. Instalación de Spatie

-  Se ha instalado **spatie/laravel-permission**: ^6.21 
-  Agregado archivo de configuración [**permission.php**](vscode-file://vscode-app/c:/Users/ccard/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Migración realizada para crear las tablas de permisos de Spatie: roles, permissions, model_has_permissions, model_has_roles, role_has_permissions

2. Se ha liberado el nombre de tabla **roles** y se ha identificado el actual sistema de permisos con el nombre **old_roles**

- Tabla roles renombrada a **old_roles** para evitar conflictos con las nuevas tablas de Spatie
- Renombrado modelo Role a OldRole que apunta a la tabla old_roles
- Renombrado RoleController a OldRoleController con sus respectivos servicios y requests

3. Refirección a Users de las relaciones de los recursos Resources, Bookmarks, Likes y Tags
Con el objetico de dotar de uso tabla Users de acuerdo con expectativas de Spatie:  
  - Actualizadas las foreign keys en las migraciones:
  - bookmarks.github_id → users.github_id
  - likes.github_id → users.github_id
  - resources.github_id → users.github_id


4. Actualizaciones en Factories y Seeders

- 🏭 Renombrado RoleFactory a OldRoleFactory
- 🌱 Actualizados seeders para usar las nuevas relaciones y factories

5. Se han adaptado los tests para la transición a Spatie
- Se modifica OldRole en lugar de Role
- Se desdobla Role factory en User Factory y OlRole factory para que los recursos relacionados con User validen los test correctamente a la vez que se mantiene el acutal sistema de permisos.
- Actualizadas las aserciones y referencias de tablas
- Tests de validación como GithubIdRule redirigido a old_roles

6. Reordenar las rutas en API por controladores para poder declarar los middlewares 
🐛 Además, corregido bug en la ruta /V2/resources (faltaba la barra inicial)


### Objetivos Conseguidos
✅ Compatibilidad mantenida: el sistema existente sigue funcionando con los "old roles"
✅ Endpoints vigentes para frontend.
✅ Base preparada: infraestructura lista para implementar el nuevo sistema de permisos de Spatie
✅ Migración segura: roles existentes (admin, student, superadmin, mentor)  preservados en old_roles
✅ Tests funcionando: Toda la suite de tests pasa correctamente
✅ Sistema antiguo de permisos identificado para futura eliminación

### Próximos Pasos
Esta PR instala Spatie, reorganiza el funcionamiento de la tabla Users y libera la tabla Roles para poder definir los roles, políticas de permisos y middleware en las rutas, de acuerdo con Spatie. 
Los próximos pasos incluirán:
1) Configurar Spatie
2) Definir los roles propiamente dichos en el seeder.
3) Añadir trait HasApiRoles en User
4) Definir policies
5) Establecer middleware en las rutas
6) Declarar nivel de autorizacion en los controladores
7) Modificar los tests
8) Eliminar gradualmente el sistema antiguo fácilmente identificable por old_roles

### 🚨 Breaking Changes
Cambios en las relaciones de modelos (Resources, Bookmarks, Likes ahora apuntan a Users)
Renombrado de controladores y servicios relacionados con roles