### PR TITLE
Added slash to avoig annoying misteriously random failing test

### DIFF
--- a/tests/Feature/ShowResourceTest.php
+++ b/tests/Feature/ShowResourceTest.php
@@ -13,7 +13,7 @@ class ShowResourceTest extends TestCase
      */
     public function test_user_can_search_for_resources(): void
     {
-        $response = $this->get('api/v2/resources?search=JavaScript'); 
+        $response = $this->get('/api/v2/resources?search=JavaScript'); 
 
         $response->assertStatus(200);
     }


### PR DESCRIPTION
La «/» que falta delante de la ruta del test produce un error caprichoso que no nos hace falta!

